### PR TITLE
Added `get_feature_names` API to encoders

### DIFF
--- a/feature_engine/base_transformers.py
+++ b/feature_engine/base_transformers.py
@@ -2,7 +2,7 @@
 classes. Provides the base functionality within the fit() and transform() methods
 shared by most transformers, like checking that input is a df, the size, NA, etc.
 """
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -147,7 +147,7 @@ class BaseNumericalTransformer(BaseEstimator, TransformerMixin):
 
     def get_feature_names(
         self,
-        input_features: List[str] = None,
+        input_features: Optional[List[Union[str, int]]] = None,
     ) -> List:
         """
         Return feature names for output features.

--- a/feature_engine/base_transformers.py
+++ b/feature_engine/base_transformers.py
@@ -2,7 +2,7 @@
 classes. Provides the base functionality within the fit() and transform() methods
 shared by most transformers, like checking that input is a df, the size, NA, etc.
 """
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -144,3 +144,26 @@ class BaseNumericalTransformer(BaseEstimator, TransformerMixin):
     # for the check_estimator tests
     def _more_tags(self):
         return _return_tags()
+
+    def get_feature_names(
+        self,
+        input_features: List[str] = None,
+    ) -> List:
+        """
+        Return feature names for output features.
+
+        Parameters
+        ----------
+        input_features : list of str of shape (n_features,)
+            String names for input features if available. By default,
+            self.variables_ is used
+
+        -------
+        feature_names : list of str of shape (n_output_features,) of feature names
+        """
+        check_is_fitted(self)
+
+        if input_features is None:
+            input_features = self.variables_
+
+        return [feature for feature in input_features if feature in self.variables_]

--- a/feature_engine/base_transformers.py
+++ b/feature_engine/base_transformers.py
@@ -97,6 +97,9 @@ class BaseNumericalTransformer(BaseEstimator, TransformerMixin):
         # find or check for numerical variables
         self.variables_ = _find_or_check_numerical_variables(X, self.variables)
 
+        # save input features
+        self.input_features_: List[Union[str, int]] = X.columns.tolist()
+
         # check if dataset contains na or inf
         _check_contains_na(X, self.variables_)
         _check_contains_inf(X, self.variables_)
@@ -145,25 +148,13 @@ class BaseNumericalTransformer(BaseEstimator, TransformerMixin):
     def _more_tags(self):
         return _return_tags()
 
-    def get_feature_names(
-        self,
-        input_features: Optional[List[Union[str, int]]] = None,
-    ) -> List:
+    def get_feature_names(self) -> List:
         """
         Return feature names for output features.
-
-        Parameters
-        ----------
-        input_features : list of str of shape (n_features,)
-            String names for input features if available. By default,
-            self.variables_ is used
 
         -------
         feature_names : list of str of shape (n_output_features,) of feature names
         """
         check_is_fitted(self)
 
-        if input_features is None:
-            input_features = self.variables_
-
-        return [feature for feature in input_features if feature in self.variables_]
+        return self.input_features_

--- a/feature_engine/discretisation/arbitrary.py
+++ b/feature_engine/discretisation/arbitrary.py
@@ -132,6 +132,9 @@ class ArbitraryDiscretiser(BaseNumericalTransformer):
 
         self.n_features_in_ = X.shape[1]
 
+        # save input features
+        self.input_features_: List[Union[str, int]] = X.columns.tolist()
+
         return self
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:

--- a/feature_engine/encoding/base_encoder.py
+++ b/feature_engine/encoding/base_encoder.py
@@ -204,3 +204,26 @@ class BaseCategoricalTransformer(BaseEstimator, TransformerMixin):
         # so we need to leave without this test
         tags_dict["_xfail_checks"]["check_estimators_nan_inf"] = "transformer allows NA"
         return tags_dict
+
+    def get_feature_names(
+        self,
+        input_features: List[str] = None,
+    ) -> List:
+        """
+        Return feature names for output features.
+
+        Parameters
+        ----------
+        input_features : list of str of shape (n_features,)
+            String names for input features if available. By default,
+            self.variables_ is used
+
+        -------
+        feature_names : list of str of shape (n_output_features,) of feature names
+        """
+        check_is_fitted(self)
+
+        if input_features is None:
+            input_features = self.variables_
+
+        return [feature for feature in input_features if feature in self.encoder_dict_]

--- a/feature_engine/encoding/base_encoder.py
+++ b/feature_engine/encoding/base_encoder.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -207,7 +207,7 @@ class BaseCategoricalTransformer(BaseEstimator, TransformerMixin):
 
     def get_feature_names(
         self,
-        input_features: List[str] = None,
+        input_features: Optional[List[Union[str, int]]] = None,
     ) -> List:
         """
         Return feature names for output features.

--- a/feature_engine/encoding/base_encoder.py
+++ b/feature_engine/encoding/base_encoder.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union
+from typing import List, Union
 
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -58,6 +58,9 @@ class BaseCategoricalTransformer(BaseEstimator, TransformerMixin):
         else:
             # select all variables or check variables entered by the user
             self.variables_ = _find_all_variables(X, self.variables)
+
+        # save input features
+        self.input_features_: List[Union[str, int]] = X.columns.tolist()
 
         # check if dataset contains na
         _check_contains_na(X, self.variables_)
@@ -205,25 +208,13 @@ class BaseCategoricalTransformer(BaseEstimator, TransformerMixin):
         tags_dict["_xfail_checks"]["check_estimators_nan_inf"] = "transformer allows NA"
         return tags_dict
 
-    def get_feature_names(
-        self,
-        input_features: Optional[List[Union[str, int]]] = None,
-    ) -> List:
+    def get_feature_names(self) -> List:
         """
         Return feature names for output features.
-
-        Parameters
-        ----------
-        input_features : list of str of shape (n_features,)
-            String names for input features if available. By default,
-            self.variables_ is used
 
         -------
         feature_names : list of str of shape (n_output_features,) of feature names
         """
         check_is_fitted(self)
 
-        if input_features is None:
-            input_features = self.variables_
-
-        return [feature for feature in input_features if feature in self.encoder_dict_]
+        return self.input_features_

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -262,7 +262,7 @@ class DecisionTreeEncoder(BaseCategoricalTransformer):
 
     def get_feature_names(
         self,
-        input_features: List[str] = None,
+        input_features: Optional[List[Union[str, int]]] = None,
     ) -> List:
         """
         Return feature names for output features.

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -260,24 +260,13 @@ class DecisionTreeEncoder(BaseCategoricalTransformer):
         """inverse_transform is not implemented for this transformer."""
         return self
 
-    def get_feature_names(
-        self,
-        input_features: Optional[List[Union[str, int]]] = None,
-    ) -> List:
+    def get_feature_names(self) -> List:
         """
         Return feature names for output features.
-
-        Parameters
-        ----------
-        input_features : list of str of shape (n_features,)
-            String names for input features if available. By default,
-            self.variables_ is used
 
         -------
         feature_names : list of str of shape (n_output_features,) of feature names
         """
         check_is_fitted(self)
 
-        return self.encoder_.named_steps.tree_discretiser.get_feature_names(
-            input_features
-        )
+        return self.encoder_.named_steps.tree_discretiser.get_feature_names()

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 
 import pandas as pd
 from sklearn.pipeline import Pipeline
+from sklearn.utils.validation import check_is_fitted
 
 from feature_engine.discretisation import DecisionTreeDiscretiser
 from feature_engine.encoding.base_encoder import BaseCategoricalTransformer
@@ -258,3 +259,25 @@ class DecisionTreeEncoder(BaseCategoricalTransformer):
     def inverse_transform(self, X: pd.DataFrame):
         """inverse_transform is not implemented for this transformer."""
         return self
+
+    def get_feature_names(
+        self,
+        input_features: List[str] = None,
+    ) -> List:
+        """
+        Return feature names for output features.
+
+        Parameters
+        ----------
+        input_features : list of str of shape (n_features,)
+            String names for input features if available. By default,
+            self.variables_ is used
+
+        -------
+        feature_names : list of str of shape (n_output_features,) of feature names
+        """
+        check_is_fitted(self)
+
+        return self.encoder_.named_steps.tree_discretiser.get_feature_names(
+            input_features
+        )

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -6,6 +6,8 @@ from typing import List, Optional, Union
 import numpy as np
 import pandas as pd
 
+from sklearn.utils.validation import check_is_fitted
+
 from feature_engine.encoding.base_encoder import BaseCategoricalTransformer
 from feature_engine.variable_manipulation import _check_input_parameter_variables
 
@@ -284,3 +286,31 @@ class OneHotEncoder(BaseCategoricalTransformer):
     def inverse_transform(self, X: pd.DataFrame):
         """inverse_transform is not implemented for this transformer."""
         return self
+
+    def get_feature_names(
+        self,
+        input_features: List[str] = None,
+    ) -> List[str]:
+        """
+        Return feature names for output features.
+
+        Parameters
+        ----------
+        input_features : list of str of shape (n_features,)
+            String names for input features if available. By default,
+            self.variables_ is used
+
+        -------
+        feature_names : list of str of shape (n_output_features,) of feature names
+        """
+        check_is_fitted(self)
+
+        if input_features is None:
+            input_features = self.variables_
+
+        feature_names = []
+        for feature in input_features:
+            for category in self.encoder_dict_[feature]:
+                feature_names.append(str(feature) + "_" + str(category))
+
+        return feature_names

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -287,30 +287,21 @@ class OneHotEncoder(BaseCategoricalTransformer):
         """inverse_transform is not implemented for this transformer."""
         return self
 
-    def get_feature_names(
-        self,
-        input_features: Optional[List[Union[str, int]]] = None,
-    ) -> List[str]:
+    def get_feature_names(self) -> List[str]:
         """
         Return feature names for output features.
-
-        Parameters
-        ----------
-        input_features : list of str of shape (n_features,)
-            String names for input features if available. By default,
-            self.variables_ is used
 
         -------
         feature_names : list of str of shape (n_output_features,) of feature names
         """
         check_is_fitted(self)
 
-        if input_features is None:
-            input_features = self.variables_
-
         feature_names = []
-        for feature in input_features:
-            for category in self.encoder_dict_[feature]:
-                feature_names.append(str(feature) + "_" + str(category))
+        for feature in self.input_features_:
+            if feature in self.encoder_dict_:
+                for category in self.encoder_dict_[feature]:
+                    feature_names.append(str(feature) + "_" + str(category))
+            else:
+                feature_names.append(feature)
 
         return feature_names

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -289,7 +289,7 @@ class OneHotEncoder(BaseCategoricalTransformer):
 
     def get_feature_names(
         self,
-        input_features: List[str] = None,
+        input_features: Optional[List[Union[str, int]]] = None,
     ) -> List[str]:
         """
         Return feature names for output features.

--- a/tests/test_discretisation/test_arbitrary_discretiser.py
+++ b/tests/test_discretisation/test_arbitrary_discretiser.py
@@ -34,3 +34,4 @@ def test_arbitrary_discretiser():
     )
     X = transformer.fit_transform(data)
     pd.testing.assert_frame_equal(X, data_t1)
+    assert transformer.get_feature_names() == X.columns.tolist()

--- a/tests/test_discretisation/test_decistion_tree_discretiser.py
+++ b/tests/test_discretisation/test_decistion_tree_discretiser.py
@@ -81,6 +81,7 @@ def test_regression(df_normal_dist):
     )
     # transform params
     assert all(x for x in np.round(X["var"].unique(), 2) if x not in X_t)
+    assert transformer.get_feature_names() == X.columns.tolist()
 
 
 def test_error_when_cv_is_string():

--- a/tests/test_discretisation/test_equal_frequency_discretiser.py
+++ b/tests/test_discretisation/test_equal_frequency_discretiser.py
@@ -28,6 +28,7 @@ def test_automatically_find_variables_and_return_as_numeric(df_normal_dist):
     # test transform output
     assert (transformer.binner_dict_["var"] == bins).all()
     assert all(x for x in X["var"].unique() if x not in X_t)
+    assert transformer.get_feature_names() == X.columns.tolist()
     # in equal frequency discretisation, all intervals get same proportion of values
     assert len((X["var"].value_counts()).unique()) == 1
 

--- a/tests/test_discretisation/test_equal_width_discretiser.py
+++ b/tests/test_discretisation/test_equal_width_discretiser.py
@@ -29,6 +29,7 @@ def test_automatically_find_variables_and_return_as_numeric(df_normal_dist):
     # transform params
     assert (transformer.binner_dict_["var"] == bins).all()
     assert all(x for x in X["var"].unique() if x not in X_t)
+    assert transformer.get_feature_names() == X.columns.tolist()
     # in equal width discretisation, intervals get different number of values
     assert all(x for x in X["var"].value_counts() if x not in val_counts)
 

--- a/tests/test_encoding/test_count_frequency_encoder.py
+++ b/tests/test_encoding/test_count_frequency_encoder.py
@@ -44,6 +44,7 @@ def test_encode_1_variable_with_counts(df_enc):
     assert encoder.n_features_in_ == 3
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
+    assert encoder.get_feature_names() == ["var_A"]
 
 
 def test_automatically_select_variables_encode_with_frequency(df_enc):
@@ -110,6 +111,7 @@ def test_automatically_select_variables_encode_with_frequency(df_enc):
     assert encoder.n_features_in_ == 3
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
 
 
 def test_error_if_encoding_method_not_permitted_value():
@@ -174,6 +176,8 @@ def test_ignore_variable_format_with_frequency(df_vartypes):
     assert encoder.n_features_in_ == 5
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
+    assert encoder.get_feature_names() == ["Name", "City", "Age", "Marks", "dob"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_column_names_are_numbers(df_numeric_columns):
@@ -201,6 +205,7 @@ def test_column_names_are_numbers(df_numeric_columns):
     assert encoder.n_features_in_ == 5
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
+    assert encoder.get_feature_names() == [0, 1, 2, 3]
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
@@ -238,3 +243,4 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     encoder = CountFrequencyEncoder(encoding_method="frequency", variables=["var_A"])
     X = encoder.fit_transform(df_enc_category_dtypes)
     assert X["var_A"].dtypes == float
+    assert encoder.get_feature_names() == ["var_A"]

--- a/tests/test_encoding/test_count_frequency_encoder.py
+++ b/tests/test_encoding/test_count_frequency_encoder.py
@@ -44,7 +44,7 @@ def test_encode_1_variable_with_counts(df_enc):
     assert encoder.n_features_in_ == 3
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_automatically_select_variables_encode_with_frequency(df_enc):
@@ -111,7 +111,7 @@ def test_automatically_select_variables_encode_with_frequency(df_enc):
     assert encoder.n_features_in_ == 3
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_error_if_encoding_method_not_permitted_value():
@@ -176,7 +176,6 @@ def test_ignore_variable_format_with_frequency(df_vartypes):
     assert encoder.n_features_in_ == 5
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
-    assert encoder.get_feature_names() == ["Name", "City", "Age", "Marks", "dob"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -205,7 +204,7 @@ def test_column_names_are_numbers(df_numeric_columns):
     assert encoder.n_features_in_ == 5
     # transform params
     pd.testing.assert_frame_equal(X, transf_df)
-    assert encoder.get_feature_names() == [0, 1, 2, 3]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
@@ -242,5 +241,5 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
 
     encoder = CountFrequencyEncoder(encoding_method="frequency", variables=["var_A"])
     X = encoder.fit_transform(df_enc_category_dtypes)
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert X["var_A"].dtypes == float
-    assert encoder.get_feature_names() == ["var_A"]

--- a/tests/test_encoding/test_decision_tree_encoder.py
+++ b/tests/test_encoding/test_decision_tree_encoder.py
@@ -32,8 +32,6 @@ def test_classification(df_enc):
     transf_df["var_A"] = [0.25] * 16 + [0.5] * 4  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.2] * 10 + [0.4] * 10  # Tree: var_B <= 0.5 -> 0.2 else 0.4
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -50,7 +48,6 @@ def test_regression(df_enc):
     )  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.044806] * 10 + [-0.079066] * 10
     pd.testing.assert_frame_equal(X.round(6), transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -84,7 +81,6 @@ def test_classification_ignore_format(df_enc_numeric):
     transf_df["var_A"] = [0.25] * 16 + [0.5] * 4  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.2] * 10 + [0.4] * 10  # Tree: var_B <= 0.5 -> 0.2 else 0.4
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -103,7 +99,6 @@ def test_regression_ignore_format(df_enc_numeric):
     )  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.044806] * 10 + [-0.079066] * 10
     pd.testing.assert_frame_equal(X.round(6), transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -117,6 +112,5 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     transf_df["var_A"] = [0.25] * 16 + [0.5] * 4  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.2] * 10 + [0.4] * 10  # Tree: var_B <= 0.5 -> 0.2 else 0.4
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
     assert X["var_A"].dtypes == float

--- a/tests/test_encoding/test_decision_tree_encoder.py
+++ b/tests/test_encoding/test_decision_tree_encoder.py
@@ -33,6 +33,9 @@ def test_classification(df_enc):
     transf_df["var_B"] = [0.2] * 10 + [0.4] * 10  # Tree: var_B <= 0.5 -> 0.2 else 0.4
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
 
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
+
 
 def test_regression(df_enc):
     random = np.random.RandomState(42)
@@ -47,6 +50,8 @@ def test_regression(df_enc):
     )  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.044806] * 10 + [-0.079066] * 10
     pd.testing.assert_frame_equal(X.round(6), transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_non_fitted_error(df_enc):
@@ -79,6 +84,8 @@ def test_classification_ignore_format(df_enc_numeric):
     transf_df["var_A"] = [0.25] * 16 + [0.5] * 4  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.2] * 10 + [0.4] * 10  # Tree: var_B <= 0.5 -> 0.2 else 0.4
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_regression_ignore_format(df_enc_numeric):
@@ -96,6 +103,8 @@ def test_regression_ignore_format(df_enc_numeric):
     )  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.044806] * 10 + [-0.079066] * 10
     pd.testing.assert_frame_equal(X.round(6), transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
@@ -108,4 +117,6 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     transf_df["var_A"] = [0.25] * 16 + [0.5] * 4  # Tree: var_A <= 1.5 -> 0.25 else 0.5
     transf_df["var_B"] = [0.2] * 10 + [0.4] * 10  # Tree: var_B <= 0.5 -> 0.2 else 0.4
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert X["var_A"].dtypes == float

--- a/tests/test_encoding/test_mean_encoder.py
+++ b/tests/test_encoding/test_mean_encoder.py
@@ -46,7 +46,7 @@ def test_user_enters_1_variable(df_enc):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_automatically_find_variables(df_enc):
@@ -113,7 +113,6 @@ def test_automatically_find_variables(df_enc):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -195,7 +194,7 @@ def test_user_enters_1_variable_ignore_format(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_automatically_find_variables_ignore_format(df_enc_numeric):
@@ -262,7 +261,6 @@ def test_automatically_find_variables_ignore_format(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -298,5 +296,5 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     ]
 
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert X["var_A"].dtypes == float

--- a/tests/test_encoding/test_mean_encoder.py
+++ b/tests/test_encoding/test_mean_encoder.py
@@ -46,6 +46,7 @@ def test_user_enters_1_variable(df_enc):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A"]
 
 
 def test_automatically_find_variables(df_enc):
@@ -112,6 +113,8 @@ def test_automatically_find_variables(df_enc):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_error_if_y_not_passed_to_fit(df_enc):
@@ -192,6 +195,7 @@ def test_user_enters_1_variable_ignore_format(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A"]
 
 
 def test_automatically_find_variables_ignore_format(df_enc_numeric):
@@ -258,6 +262,8 @@ def test_automatically_find_variables_ignore_format(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
@@ -292,4 +298,5 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     ]
 
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
+    assert encoder.get_feature_names() == ["var_A"]
     assert X["var_A"].dtypes == float

--- a/tests/test_encoding/test_onehot_encoder.py
+++ b/tests/test_encoding/test_onehot_encoder.py
@@ -43,29 +43,6 @@ def test_encode_categories_in_k_binary_plus_select_vars_automatically(df_enc_big
     assert encoder.n_features_in_ == 3
     # test transform output
     assert X.sum().to_dict() == transf
-    assert encoder.get_feature_names() == [
-        "var_A_A",
-        "var_A_B",
-        "var_A_C",
-        "var_A_D",
-        "var_A_E",
-        "var_A_F",
-        "var_A_G",
-        "var_B_A",
-        "var_B_B",
-        "var_B_C",
-        "var_B_D",
-        "var_B_E",
-        "var_B_F",
-        "var_B_G",
-        "var_C_A",
-        "var_C_B",
-        "var_C_C",
-        "var_C_D",
-        "var_C_E",
-        "var_C_F",
-        "var_C_G",
-    ]
     assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_A" not in X.columns
 
@@ -103,20 +80,7 @@ def test_encode_categories_in_k_minus_1_binary_plus_list_of_variables(df_enc_big
     # test transform output
     for col in transf.keys():
         assert X[col].sum() == transf[col]
-    assert encoder.get_feature_names() == [
-        "var_A_A",
-        "var_A_B",
-        "var_A_C",
-        "var_A_D",
-        "var_A_E",
-        "var_A_F",
-        "var_B_A",
-        "var_B_B",
-        "var_B_C",
-        "var_B_D",
-        "var_B_E",
-        "var_B_F",
-    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_B" not in X.columns
     assert "var_B_G" not in X.columns
     assert "var_C" in X.columns
@@ -152,20 +116,6 @@ def test_encode_top_categories(df_enc_big):
     # note the order, it's a important
     # features are sorted in the by the name of the input column
     # and then by the number of occurrences of the category
-    assert encoder.get_feature_names() == [
-        "var_A_B",
-        "var_A_D",
-        "var_A_A",
-        "var_A_G",
-        "var_B_A",
-        "var_B_D",
-        "var_B_B",
-        "var_B_G",
-        "var_C_C",
-        "var_C_D",
-        "var_C_B",
-        "var_C_G",
-    ]
     assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_B" not in X.columns
     assert "var_B_F" not in X.columns
@@ -223,14 +173,6 @@ def test_encode_numerical_variables(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
-    assert encoder.get_feature_names() == [
-        "var_A_1",
-        "var_A_2",
-        "var_A_3",
-        "var_B_1",
-        "var_B_2",
-        "var_B_3",
-    ]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -264,14 +206,6 @@ def test_variables_cast_as_category(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
-    assert encoder.get_feature_names() == [
-        "var_A_1",
-        "var_A_2",
-        "var_A_3",
-        "var_B_1",
-        "var_B_2",
-        "var_B_3",
-    ]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -313,15 +247,7 @@ def test_encode_into_k_binary_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
-    assert encoder.get_feature_names() == [
-        "var_A_A",
-        "var_A_B",
-        "var_A_C",
-        "var_B_A",
-        "var_B_B",
-        "var_B_C",
-        "var_C_A",
-    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_C_B" not in X.columns
 
 
@@ -348,13 +274,7 @@ def test_encode_into_kminus1_binary_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
-    assert encoder.get_feature_names() == [
-        "var_A_A",
-        "var_A_B",
-        "var_B_A",
-        "var_B_B",
-        "var_C_A",
-    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_C_B" not in X.columns
 
 
@@ -381,7 +301,7 @@ def test_encode_into_top_categories_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
-    assert encoder.get_feature_names() == ["var_A_B", "var_B_A", "var_C_A"]
+    # assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_C_B" not in X.columns
 
     # top_categories = 2
@@ -407,11 +327,5 @@ def test_encode_into_top_categories_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
-    assert encoder.get_feature_names() == [
-        "var_A_B",
-        "var_A_A",
-        "var_B_A",
-        "var_B_B",
-        "var_C_A",
-    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_C_B" not in X.columns

--- a/tests/test_encoding/test_onehot_encoder.py
+++ b/tests/test_encoding/test_onehot_encoder.py
@@ -43,6 +43,30 @@ def test_encode_categories_in_k_binary_plus_select_vars_automatically(df_enc_big
     assert encoder.n_features_in_ == 3
     # test transform output
     assert X.sum().to_dict() == transf
+    assert encoder.get_feature_names() == [
+        "var_A_A",
+        "var_A_B",
+        "var_A_C",
+        "var_A_D",
+        "var_A_E",
+        "var_A_F",
+        "var_A_G",
+        "var_B_A",
+        "var_B_B",
+        "var_B_C",
+        "var_B_D",
+        "var_B_E",
+        "var_B_F",
+        "var_B_G",
+        "var_C_A",
+        "var_C_B",
+        "var_C_C",
+        "var_C_D",
+        "var_C_E",
+        "var_C_F",
+        "var_C_G",
+    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_A" not in X.columns
 
 
@@ -79,6 +103,20 @@ def test_encode_categories_in_k_minus_1_binary_plus_list_of_variables(df_enc_big
     # test transform output
     for col in transf.keys():
         assert X[col].sum() == transf[col]
+    assert encoder.get_feature_names() == [
+        "var_A_A",
+        "var_A_B",
+        "var_A_C",
+        "var_A_D",
+        "var_A_E",
+        "var_A_F",
+        "var_B_A",
+        "var_B_B",
+        "var_B_C",
+        "var_B_D",
+        "var_B_E",
+        "var_B_F",
+    ]
     assert "var_B" not in X.columns
     assert "var_B_G" not in X.columns
     assert "var_C" in X.columns
@@ -111,6 +149,24 @@ def test_encode_top_categories(df_enc_big):
     # test transform output
     for col in transf.keys():
         assert X[col].sum() == transf[col]
+    # note the order, it's a important
+    # features are sorted in the by the name of the input column
+    # and then by the number of occurrences of the category
+    assert encoder.get_feature_names() == [
+        "var_A_B",
+        "var_A_D",
+        "var_A_A",
+        "var_A_G",
+        "var_B_A",
+        "var_B_D",
+        "var_B_B",
+        "var_B_G",
+        "var_C_C",
+        "var_C_D",
+        "var_C_B",
+        "var_C_G",
+    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert "var_B" not in X.columns
     assert "var_B_F" not in X.columns
 
@@ -167,6 +223,15 @@ def test_encode_numerical_variables(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
+    assert encoder.get_feature_names() == [
+        "var_A_1",
+        "var_A_2",
+        "var_A_3",
+        "var_B_1",
+        "var_B_2",
+        "var_B_3",
+    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_variables_cast_as_category(df_enc_numeric):
@@ -199,6 +264,15 @@ def test_variables_cast_as_category(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
+    assert encoder.get_feature_names() == [
+        "var_A_1",
+        "var_A_2",
+        "var_A_3",
+        "var_B_1",
+        "var_B_2",
+        "var_B_3",
+    ]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 @pytest.fixture(scope="module")
@@ -239,6 +313,15 @@ def test_encode_into_k_binary_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
+    assert encoder.get_feature_names() == [
+        "var_A_A",
+        "var_A_B",
+        "var_A_C",
+        "var_B_A",
+        "var_B_B",
+        "var_B_C",
+        "var_C_A",
+    ]
     assert "var_C_B" not in X.columns
 
 
@@ -265,6 +348,13 @@ def test_encode_into_kminus1_binary_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
+    assert encoder.get_feature_names() == [
+        "var_A_A",
+        "var_A_B",
+        "var_B_A",
+        "var_B_B",
+        "var_C_A",
+    ]
     assert "var_C_B" not in X.columns
 
 
@@ -291,6 +381,7 @@ def test_encode_into_top_categories_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
+    assert encoder.get_feature_names() == ["var_A_B", "var_B_A", "var_C_A"]
     assert "var_C_B" not in X.columns
 
     # top_categories = 2
@@ -316,4 +407,11 @@ def test_encode_into_top_categories_plus_drop_binary(df_enc_binary):
     assert encoder.n_features_in_ == 4
     # test transform output
     pd.testing.assert_frame_equal(X, transf)
+    assert encoder.get_feature_names() == [
+        "var_A_B",
+        "var_A_A",
+        "var_B_A",
+        "var_B_B",
+        "var_C_A",
+    ]
     assert "var_C_B" not in X.columns

--- a/tests/test_encoding/test_ordinal_encoder.py
+++ b/tests/test_encoding/test_ordinal_encoder.py
@@ -24,7 +24,7 @@ def test_ordered_encoding_1_variable(df_enc):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_arbitrary_encoding_automatically_find_variables(df_enc):
@@ -49,7 +49,7 @@ def test_arbitrary_encoding_automatically_find_variables(df_enc):
     assert encoder.n_features_in_ == 3
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df)
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_error_if_encoding_method_not_allowed():
@@ -117,7 +117,7 @@ def test_ordered_encoding_1_variable_ignore_format(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_arbitrary_encoding_automatically_find_variables_ignore_format(df_enc_numeric):
@@ -144,7 +144,6 @@ def test_arbitrary_encoding_automatically_find_variables_ignore_format(df_enc_nu
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df)
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -160,5 +159,5 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
 
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert X["var_A"].dtypes == int

--- a/tests/test_encoding/test_ordinal_encoder.py
+++ b/tests/test_encoding/test_ordinal_encoder.py
@@ -24,6 +24,7 @@ def test_ordered_encoding_1_variable(df_enc):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A"]
 
 
 def test_arbitrary_encoding_automatically_find_variables(df_enc):
@@ -48,6 +49,7 @@ def test_arbitrary_encoding_automatically_find_variables(df_enc):
     assert encoder.n_features_in_ == 3
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df)
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
 
 
 def test_error_if_encoding_method_not_allowed():
@@ -115,6 +117,7 @@ def test_ordered_encoding_1_variable_ignore_format(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A"]
 
 
 def test_arbitrary_encoding_automatically_find_variables_ignore_format(df_enc_numeric):
@@ -141,6 +144,8 @@ def test_arbitrary_encoding_automatically_find_variables_ignore_format(df_enc_nu
     assert encoder.n_features_in_ == 2
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df)
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
@@ -155,4 +160,5 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
 
     # test transform output
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
+    assert encoder.get_feature_names() == ["var_A"]
     assert X["var_A"].dtypes == int

--- a/tests/test_encoding/test_probability_ratio_encoder.py
+++ b/tests/test_encoding/test_probability_ratio_encoder.py
@@ -47,6 +47,7 @@ def test_ratio_with_one_variable(df_enc):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A"]
 
 
 def test_logratio_and_automaticcally_select_variables(df_enc):
@@ -114,6 +115,8 @@ def test_logratio_and_automaticcally_select_variables(df_enc):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
     # test error raise
     with pytest.raises(ValueError):
@@ -249,6 +252,8 @@ def test_logratio_on_numerical_variables(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
     # test error raise
     with pytest.raises(ValueError):

--- a/tests/test_encoding/test_probability_ratio_encoder.py
+++ b/tests/test_encoding/test_probability_ratio_encoder.py
@@ -47,7 +47,7 @@ def test_ratio_with_one_variable(df_enc):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_logratio_and_automaticcally_select_variables(df_enc):
@@ -115,7 +115,6 @@ def test_logratio_and_automaticcally_select_variables(df_enc):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
     # test error raise
@@ -252,7 +251,6 @@ def test_logratio_on_numerical_variables(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
     # test error raise

--- a/tests/test_encoding/test_rare_label_encoder.py
+++ b/tests/test_encoding/test_rare_label_encoder.py
@@ -44,7 +44,6 @@ def test_defo_params_plus_automatically_find_variables(df_enc_big):
     assert encoder.n_features_in_ == 3
     # test transform output
     pd.testing.assert_frame_equal(X, df)
-    assert encoder.get_feature_names() == ["var_A", "var_B", "var_C"]
     assert encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -89,7 +88,7 @@ def test_user_provides_grouping_label_name_and_variable_list(df_enc_big):
     assert encoder.n_features_in_ == 3
     # test transform output
     pd.testing.assert_frame_equal(X, df)
-    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_error_if_tol_not_between_0_and_1():
@@ -155,6 +154,7 @@ def test_max_n_categories(df_enc_big):
     }
     df = pd.DataFrame(df)
     pd.testing.assert_frame_equal(X, df)
+    assert rare_encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_max_n_categories_with_numeric_var(df_enc_numeric):
@@ -175,7 +175,6 @@ def test_max_n_categories_with_numeric_var(df_enc_numeric):
         assert str(list(X["var_A"])[i]) == str(list(df["var_A"])[i])
         assert str(list(X["var_B"])[i]) == str(list(df["var_B"])[i])
 
-    assert rare_encoder.get_feature_names() == ["var_A", "var_B"]
     assert rare_encoder.get_feature_names() == X.columns.tolist()
 
 
@@ -219,5 +218,4 @@ def test_variables_cast_as_category(df_enc_big):
 
     # test transform output
     pd.testing.assert_frame_equal(X, df)
-    assert encoder.get_feature_names() == ["var_A", "var_B", "var_C"]
     assert encoder.get_feature_names() == X.columns.tolist()

--- a/tests/test_encoding/test_rare_label_encoder.py
+++ b/tests/test_encoding/test_rare_label_encoder.py
@@ -44,6 +44,8 @@ def test_defo_params_plus_automatically_find_variables(df_enc_big):
     assert encoder.n_features_in_ == 3
     # test transform output
     pd.testing.assert_frame_equal(X, df)
+    assert encoder.get_feature_names() == ["var_A", "var_B", "var_C"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_user_provides_grouping_label_name_and_variable_list(df_enc_big):
@@ -87,6 +89,7 @@ def test_user_provides_grouping_label_name_and_variable_list(df_enc_big):
     assert encoder.n_features_in_ == 3
     # test transform output
     pd.testing.assert_frame_equal(X, df)
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
 
 
 def test_error_if_tol_not_between_0_and_1():
@@ -172,6 +175,9 @@ def test_max_n_categories_with_numeric_var(df_enc_numeric):
         assert str(list(X["var_A"])[i]) == str(list(df["var_A"])[i])
         assert str(list(X["var_B"])[i]) == str(list(df["var_B"])[i])
 
+    assert rare_encoder.get_feature_names() == ["var_A", "var_B"]
+    assert rare_encoder.get_feature_names() == X.columns.tolist()
+
 
 def test_variables_cast_as_category(df_enc_big):
     # test case 1: defo params, automatically select variables
@@ -210,5 +216,8 @@ def test_variables_cast_as_category(df_enc_big):
     # test fit attr
     assert encoder.variables_ == ["var_A", "var_B", "var_C"]
     assert encoder.n_features_in_ == 3
+
     # test transform output
     pd.testing.assert_frame_equal(X, df)
+    assert encoder.get_feature_names() == ["var_A", "var_B", "var_C"]
+    assert encoder.get_feature_names() == X.columns.tolist()

--- a/tests/test_encoding/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe_encoder.py
@@ -78,6 +78,8 @@ def test_automatically_select_variables(df_enc):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_error_target_is_not_passed(df_enc):
@@ -235,6 +237,8 @@ def test_on_numerical_variables(df_enc_numeric):
     assert encoder.n_features_in_ == 2
     # transform params
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]])
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
@@ -291,4 +295,6 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     ]
 
     pd.testing.assert_frame_equal(X, transf_df[["var_A", "var_B"]], check_dtype=False)
+    assert encoder.get_feature_names() == ["var_A", "var_B"]
+    assert encoder.get_feature_names() == X.columns.tolist()
     assert X["var_A"].dtypes == float


### PR DESCRIPTION
+ added checks for feature name output on tests

This allows the use of  things like [eli5](https://eli5.readthedocs.io/en/latest/) alongside feature engine. 

Important links:
https://scikit-learn.org/stable/glossary.html#term-get_feature_names