### PR TITLE
adds functionality to avoid selecting datetime variables as if they were categorical closes #336

### DIFF
--- a/feature_engine/variable_manipulation.py
+++ b/feature_engine/variable_manipulation.py
@@ -123,7 +123,10 @@ def _find_or_check_categorical_variables(
             column
             for column in X.select_dtypes(exclude="number")
             if is_object(X[column])
-            and not is_datetime(pd.to_datetime(X[column], errors="ignore", utc=True))
+            and (
+                is_numeric(pd.to_numeric(X[column], errors="ignore"))
+                or not is_datetime(pd.to_datetime(X[column], errors="ignore", utc=True))
+            )
             or (
                 is_categorical(X[column])
                 and (
@@ -143,7 +146,10 @@ def _find_or_check_categorical_variables(
     elif isinstance(variables, (str, int)):
         if (
             is_object(X[variables])
-            and not is_datetime(pd.to_datetime(X[variables], errors="ignore"))
+            and (
+                is_numeric(pd.to_numeric(X[variables], errors="ignore"))
+                or not is_datetime(pd.to_datetime(X[variables], errors="ignore"))
+            )
             or (
                 is_categorical(X[variables])
                 and (
@@ -169,8 +175,11 @@ def _find_or_check_categorical_variables(
                 for column in variables
                 if not (
                     is_object(X[column])
-                    and not is_datetime(
-                        pd.to_datetime(X[column], errors="ignore", utc=True)
+                    and (
+                        is_numeric(pd.to_numeric(X[column], errors="ignore"))
+                        or not is_datetime(
+                            pd.to_datetime(X[column], errors="ignore", utc=True)
+                        )
                     )
                 )
                 and not (

--- a/feature_engine/variable_manipulation.py
+++ b/feature_engine/variable_manipulation.py
@@ -144,7 +144,7 @@ def _find_or_check_categorical_variables(
             )
 
     elif isinstance(variables, (str, int)):
-        if contains_categorical(X[variables]):
+        if is_categorical(X[variables]) or is_object(X[variables]):
             variables = [variables]
         else:
             raise TypeError("The variable entered is not categorical.")
@@ -155,11 +155,7 @@ def _find_or_check_categorical_variables(
 
         # check that user entered variables are of type categorical
         else:
-            vars_non_cat = [
-                column for column in variables
-                if not contains_categorical(X[column])
-            ]
-            if len(vars_non_cat) > 0:
+            if len(X[variables].select_dtypes(exclude=["O", "category"]).columns) > 0:
                 raise TypeError(
                     "Some of the variables are not categorical. Please cast them as "
                     "categorical or object before using this transformer."

--- a/tests/test_variable_manipulation.py
+++ b/tests/test_variable_manipulation.py
@@ -80,6 +80,8 @@ def test_find_or_check_categorical_variables(
     with pytest.raises(TypeError):
         assert _find_or_check_categorical_variables(df_datetime, "datetime_range")
     with pytest.raises(TypeError):
+        assert _find_or_check_categorical_variables(df_datetime, ["datetime_range"])
+    with pytest.raises(TypeError):
         assert _find_or_check_categorical_variables(df_numeric_columns, 3)
     with pytest.raises(TypeError):
         assert _find_or_check_categorical_variables(df_numeric_columns, [0, 2])
@@ -113,7 +115,7 @@ def test_find_or_check_categorical_variables(
         "date_obj1",
     ]
 
-    # vars specified, index is numeric
+    # vars specified, column name is integer
     assert _find_or_check_categorical_variables(df_numeric_columns, [0, 1]) == [0, 1]
     assert _find_or_check_categorical_variables(df_numeric_columns, 0) == [0]
     assert _find_or_check_categorical_variables(df_numeric_columns, 1) == [1]

--- a/tests/test_variable_manipulation.py
+++ b/tests/test_variable_manipulation.py
@@ -80,10 +80,6 @@ def test_find_or_check_categorical_variables(
     with pytest.raises(TypeError):
         assert _find_or_check_categorical_variables(df_datetime, "datetime_range")
     with pytest.raises(TypeError):
-        assert _find_or_check_categorical_variables(df_datetime, "date_obj1")
-    with pytest.raises(TypeError):
-        assert _find_or_check_categorical_variables(df_datetime, ["Name", "date_obj2"])
-    with pytest.raises(TypeError):
         assert _find_or_check_categorical_variables(df_numeric_columns, 3)
     with pytest.raises(TypeError):
         assert _find_or_check_categorical_variables(df_numeric_columns, [0, 2])
@@ -108,7 +104,14 @@ def test_find_or_check_categorical_variables(
 
     # when vars are specified
     assert _find_or_check_categorical_variables(df_vartypes, "Name") == ["Name"]
+    assert _find_or_check_categorical_variables(df_datetime, "date_obj1") == [
+        "date_obj1"
+    ]
     assert _find_or_check_categorical_variables(df_vartypes, vars_cat) == vars_cat
+    assert _find_or_check_categorical_variables(df_datetime, ["Name", "date_obj1"]) == [
+        "Name",
+        "date_obj1",
+    ]
 
     # vars specified, index is numeric
     assert _find_or_check_categorical_variables(df_numeric_columns, [0, 1]) == [0, 1]
@@ -150,6 +153,7 @@ def test_find_or_check_categorical_variables(
     )
     with pytest.raises(ValueError):
         assert _find_or_check_categorical_variables(tz_time, None)
+    assert _find_or_check_categorical_variables(tz_time, "time_objTZ") == ["time_objTZ"]
 
 
 def test_find_or_check_datetime_variables(df_datetime):

--- a/tests/test_variable_manipulation.py
+++ b/tests/test_variable_manipulation.py
@@ -126,6 +126,17 @@ def test_find_or_check_categorical_variables(
     df_datetime["datetime_range"] = df_datetime["datetime_range"].astype("category")
     assert _find_or_check_categorical_variables(df_datetime, None) == ["Name"]
 
+    df_vartypes["Marks"] = df_vartypes["Marks"].astype("O")
+    assert _find_or_check_categorical_variables(df_vartypes, "Marks") == ["Marks"]
+    assert _find_or_check_categorical_variables(df_vartypes, ["Name", "Marks"]) == [
+        "Name",
+        "Marks",
+    ]
+    assert _find_or_check_categorical_variables(df_vartypes, None) == vars_cat + [
+        "Age",
+        "Marks",
+    ]
+
     tz_time = pd.DataFrame(
         {"time_objTZ": df_datetime["time_obj"].add(["+5", "+11", "-3", "-8"])}
     )

--- a/tests/test_variable_manipulation.py
+++ b/tests/test_variable_manipulation.py
@@ -133,9 +133,16 @@ def test_find_or_check_categorical_variables(
     # object-like datetime
     df_datetime["date_obj1"] = df_datetime["date_obj1"].astype("category")
     assert _find_or_check_categorical_variables(df_datetime, None) == ["Name"]
+    assert _find_or_check_categorical_variables(df_datetime, ["Name", "date_obj1"]) == [
+        "Name",
+        "date_obj1",
+    ]
     # datetime64
     df_datetime["datetime_range"] = df_datetime["datetime_range"].astype("category")
     assert _find_or_check_categorical_variables(df_datetime, None) == ["Name"]
+    assert _find_or_check_categorical_variables(
+        df_datetime, ["Name", "datetime_range"]
+    ) == ["Name", "datetime_range"]
 
     # numeric var cast as object
     df_vartypes["Marks"] = df_vartypes["Marks"].astype("O")


### PR DESCRIPTION
Hi @solegalli 
this time the commit history shouldn't be too messy.

In case you're wondering why the condition for a variable being categorical is so verbose:
Remember about pd.to_datetime working on numeric columns? 
While that might be convenient for the check estimators, it turns out to be pretty annoying when we need to discriminate between variables that contain datetime/categorical data. I'll explain the two problematic cases that justify the logic I implemented, guiding you through the commits.

- Problematic case 1: categorical variables with integer category types - e.g. `var = [1, 4, 7, 0].astype("category")`
What happens here is that pd.to_datetime(var) returns `ValueError: Unable to fill values because Int64Index cannot contain NA` even when `errors="ignore"`. To prevent that, we need to run the datetime check only when var.dtype.categories is not an integer (or a number, for all matters). 
This is addressed in the first commit of this PR [here](https://github.com/feature-engine/feature_engine/blob/9bb5fc1ed0c79c1cd5941a53da8402c89d4cab31/feature_engine/variable_manipulation.py#L128-L132).

- Problematic case 2: numerical variables cast as object - e.g. `var = ["0", "9", "25", "11"]`
Assumption: we want it to be considered a categorical var (I noticed this is the case in several tests from other modules).
What happens here is that pd.to_datetime(var) converts _var_ back into a numeric variable and then converts it (successfully) to datetime. But since it's now a datetime, as things stand, it will not be returned by the categorical checker function. Therefore, we need to run the datetime check only if we can't convert _var_ into a numeric type. This is what 4123570e7aa303ca2a4b59c47812139fb117038b addresses, leveraging pd.to_numeric.

Now that hopefully things are clearer, there's a couple more things worth mentioning:
- since the typecheck logic was verbose and repeated across the different cases of the _variables_ argument, I decided to refactor it in a new function. I named it _contains\_categorical_ because as things stand _is\_categorical_ is already taken in the namespace of that file. You tell me how to rename that more properly
- the above cases are most likely not accounted for in _find\_or\_check\_datetime\_variables_ and consequently in the _DatetimeFeatures_ transformer. The tests might have been thorough, but turns out the tests are never thorough enough. I guess I'll try and fix that in a separate issue? Shouldn't take too long.
- I finally decided to rearrange the tests for the categorical checker, along the lines of the datetime checker tests (we start with type errors and value errors, then variables=None, etc.). Let me know if it's ok or you'd rather revert to previous state

