### PR TITLE
updates datetime variable checker function to deal with cat/obj controversial cases raised in #336

### DIFF
--- a/feature_engine/variable_manipulation.py
+++ b/feature_engine/variable_manipulation.py
@@ -170,6 +170,25 @@ def _find_or_check_categorical_variables(
     return variables
 
 
+def _is_categorical_and_is_datetime(column: pd.Series) -> bool:
+
+    # check for datetime only if object cannot be cast as numeric because
+    # if it could pd.to_datetime would convert it to datetime regardless
+    if is_object(column):
+        is_categorical_and_is_datetime = not is_numeric(
+            pd.to_numeric(column, errors="ignore")
+        ) and is_datetime(pd.to_datetime(column, errors="ignore", utc=True))
+
+    # check for datetime only if the type of the categories is not numeric
+    # because pd.to_datetime throws an error when it is an integer
+    elif is_categorical(column):
+        is_categorical_and_is_datetime = not is_numeric(
+            column.dtype.categories
+        ) and is_datetime(pd.to_datetime(column, errors="ignore", utc=True))
+
+    return is_categorical_and_is_datetime
+
+
 def _find_or_check_datetime_variables(
     X: pd.DataFrame, variables: Variables = None
 ) -> List[Union[str, int]]:
@@ -191,8 +210,7 @@ def _find_or_check_datetime_variables(
         variables = [
             column
             for column in X.select_dtypes(exclude="number").columns
-            if is_datetime(X[column])
-            or is_datetime(pd.to_datetime(X[column], errors="ignore", utc=True))
+            if is_datetime(X[column]) or _is_categorical_and_is_datetime(X[column])
         ]
 
         if len(variables) == 0:
@@ -202,7 +220,7 @@ def _find_or_check_datetime_variables(
 
         if is_datetime(X[variables]) or (
             not is_numeric(X[variables])
-            and is_datetime(pd.to_datetime(X[variables], errors="ignore", utc=True))
+            and _is_categorical_and_is_datetime(X[variables])
         ):
             variables = [variables]
         else:
@@ -216,14 +234,9 @@ def _find_or_check_datetime_variables(
         else:
             vars_non_dt = [
                 column
-                for column in variables
+                for column in X[variables].select_dtypes(exclude="datetime")
                 if is_numeric(X[column])
-                or (
-                    not is_datetime(X[column])
-                    and not is_datetime(
-                        pd.to_datetime(X[column], errors="ignore", utc=True)
-                    )
-                )
+                or not _is_categorical_and_is_datetime(X[column])
             ]
 
             if len(vars_non_dt) > 0:

--- a/tests/test_variable_manipulation.py
+++ b/tests/test_variable_manipulation.py
@@ -237,22 +237,26 @@ def test_find_or_check_datetime_variables(df_datetime):
         == vars_convertible_to_dt
     )
 
-    # int var cast as categorical
-    df_datetime["Age"] = df_datetime["Age"].astype("category")
-    with pytest.raises(TypeError):
-        assert _find_or_check_datetime_variables(df_datetime, variables="Age")
-    with pytest.raises(TypeError):
-        assert _find_or_check_datetime_variables(df_datetime, variables=["Age"])
-    with pytest.raises(ValueError) as errinfo:
-        assert _find_or_check_datetime_variables(df_datetime[["Age"]], variables=None)
-    assert str(errinfo.value) == "No datetime variables found in this dataframe."
-    assert (
-        _find_or_check_datetime_variables(df_datetime, variables=None)
-        == vars_convertible_to_dt
-    )
 
-    # numeric var cast as object
+@pytest.fixture()
+def cast_age_as_cat(df_datetime):
+    df_datetime["Age"] = df_datetime["Age"].astype("category")
+    return df_datetime
+
+
+@pytest.fixture()
+def cast_age_as_obj(df_datetime):
     df_datetime["Age"] = df_datetime["Age"].astype("O")
+    return df_datetime
+
+
+@pytest.mark.parametrize(
+    "df_age_cast_as_categorical", ["cast_age_as_cat", "cast_age_as_obj"]
+)
+def test_dt_checker_when_numeric_is_cast_as_category_or_object(
+    df_age_cast_as_categorical, request
+):
+    df_datetime = request.getfixturevalue(df_age_cast_as_categorical)
     with pytest.raises(TypeError):
         assert _find_or_check_datetime_variables(df_datetime, variables="Age")
     with pytest.raises(TypeError):
@@ -260,10 +264,12 @@ def test_find_or_check_datetime_variables(df_datetime):
     with pytest.raises(ValueError) as errinfo:
         assert _find_or_check_datetime_variables(df_datetime[["Age"]], variables=None)
     assert str(errinfo.value) == "No datetime variables found in this dataframe."
-    assert (
-        _find_or_check_datetime_variables(df_datetime, variables=None)
-        == vars_convertible_to_dt
-    )
+    assert _find_or_check_datetime_variables(df_datetime, variables=None) == [
+        "datetime_range",
+        "date_obj1",
+        "date_obj2",
+        "time_obj",
+    ]
 
 
 def test_find_all_variables(df_vartypes):

--- a/tests/test_variable_manipulation.py
+++ b/tests/test_variable_manipulation.py
@@ -68,6 +68,12 @@ def test_find_or_check_numerical_variables(df_vartypes, df_numeric_columns):
     assert _find_or_check_numerical_variables(df_numeric_columns, 2) == [2]
 
 
+def _cast_var_as_type(df, var, new_type):
+    df_copy = df.copy()
+    df_copy[var] = df[var].astype(new_type)
+    return df_copy
+
+
 def test_find_or_check_categorical_variables(
     df_vartypes, df_datetime, df_numeric_columns
 ):
@@ -120,15 +126,6 @@ def test_find_or_check_categorical_variables(
     assert _find_or_check_categorical_variables(df_numeric_columns, 0) == [0]
     assert _find_or_check_categorical_variables(df_numeric_columns, 1) == [1]
 
-    # numeric var cast as category
-    df_vartypes["Age"] = df_vartypes["Age"].astype("category")
-    assert _find_or_check_categorical_variables(df_vartypes, "Age") == ["Age"]
-    assert _find_or_check_categorical_variables(df_vartypes, None) == vars_cat + ["Age"]
-    assert _find_or_check_categorical_variables(df_vartypes, ["Name", "Age"]) == [
-        "Name",
-        "Age",
-    ]
-
     # datetime vars cast as category
     # object-like datetime
     df_datetime["date_obj1"] = df_datetime["date_obj1"].astype("category")
@@ -144,18 +141,6 @@ def test_find_or_check_categorical_variables(
         df_datetime, ["Name", "datetime_range"]
     ) == ["Name", "datetime_range"]
 
-    # numeric var cast as object
-    df_vartypes["Marks"] = df_vartypes["Marks"].astype("O")
-    assert _find_or_check_categorical_variables(df_vartypes, "Marks") == ["Marks"]
-    assert _find_or_check_categorical_variables(df_vartypes, ["Name", "Marks"]) == [
-        "Name",
-        "Marks",
-    ]
-    assert _find_or_check_categorical_variables(df_vartypes, None) == vars_cat + [
-        "Age",
-        "Marks",
-    ]
-
     # time-aware datetime var
     tz_time = pd.DataFrame(
         {"time_objTZ": df_datetime["time_obj"].add(["+5", "+11", "-3", "-8"])}
@@ -163,6 +148,26 @@ def test_find_or_check_categorical_variables(
     with pytest.raises(ValueError):
         assert _find_or_check_categorical_variables(tz_time, None)
     assert _find_or_check_categorical_variables(tz_time, "time_objTZ") == ["time_objTZ"]
+
+
+@pytest.mark.parametrize(
+    "_num_var, _cat_type",
+    [("Age", "category"), ("Age", "O"), ("Marks", "category"), ("Marks", "O")],
+)
+def test_find_or_check_categorical_variables_when_numeric_is_cast_as_category_or_object(
+    df_vartypes, _num_var, _cat_type
+):
+    df_vartypes = _cast_var_as_type(df_vartypes, _num_var, _cat_type)
+    assert _find_or_check_categorical_variables(df_vartypes, _num_var) == [_num_var]
+    assert _find_or_check_categorical_variables(df_vartypes, None) == [
+        "Name",
+        "City",
+        _num_var,
+    ]
+    assert _find_or_check_categorical_variables(df_vartypes, ["Name", _num_var]) == [
+        "Name",
+        _num_var,
+    ]
 
 
 def test_find_or_check_datetime_variables(df_datetime):
@@ -238,31 +243,19 @@ def test_find_or_check_datetime_variables(df_datetime):
     )
 
 
-@pytest.fixture()
-def cast_age_as_cat(df_datetime):
-    df_datetime["Age"] = df_datetime["Age"].astype("category")
-    return df_datetime
-
-
-@pytest.fixture()
-def cast_age_as_obj(df_datetime):
-    df_datetime["Age"] = df_datetime["Age"].astype("O")
-    return df_datetime
-
-
-@pytest.mark.parametrize(
-    "df_age_cast_as_categorical", ["cast_age_as_cat", "cast_age_as_obj"]
-)
-def test_dt_checker_when_numeric_is_cast_as_category_or_object(
-    df_age_cast_as_categorical, request
+@pytest.mark.parametrize("_num_var, _cat_type", [("Age", "category"), ("Age", "O")])
+def test_find_or_check_datetime_variables_when_numeric_is_cast_as_category_or_object(
+    df_datetime, _num_var, _cat_type
 ):
-    df_datetime = request.getfixturevalue(df_age_cast_as_categorical)
+    df_datetime = _cast_var_as_type(df_datetime, _num_var, _cat_type)
     with pytest.raises(TypeError):
-        assert _find_or_check_datetime_variables(df_datetime, variables="Age")
+        assert _find_or_check_datetime_variables(df_datetime, variables=_num_var)
     with pytest.raises(TypeError):
-        assert _find_or_check_datetime_variables(df_datetime, variables=["Age"])
+        assert _find_or_check_datetime_variables(df_datetime, variables=[_num_var])
     with pytest.raises(ValueError) as errinfo:
-        assert _find_or_check_datetime_variables(df_datetime[["Age"]], variables=None)
+        assert _find_or_check_datetime_variables(
+            df_datetime[[_num_var]], variables=None
+        )
     assert str(errinfo.value) == "No datetime variables found in this dataframe."
     assert _find_or_check_datetime_variables(df_datetime, variables=None) == [
         "datetime_range",


### PR DESCRIPTION
Hi @solegalli 
The last commit is a bit meh in that it actually needs almost as many lines of code as repeating the same tests for a different var type. The _request_ argument in the last commit is a trick I found to let mark.parametrize get their values from fixtures. Otherwise those tests could be put into a standard function (no decorators or anything) that gets called within _tests\_find\_or\_check\_datetime\_vars_. But honestly I might just drop that commit, you tell me

Also I left a comment with a quick question in the issue336 PR you've merged, would you mind having a look when you have time