### PR TITLE
correct typo in periods in get_feature_names_out

### DIFF
--- a/feature_engine/timeseries/forecasting/lag_features.py
+++ b/feature_engine/timeseries/forecasting/lag_features.py
@@ -245,7 +245,7 @@ class LagFeatures(BaseEstimator, TransformerMixin):
         elif isinstance(self.periods, list):
             feature_names = [
                 str(feature) + f"_lag_{pr}"
-                for pr in self.perdiods
+                for pr in self.periods
                 for feature in input_features
             ]
         else:


### PR DESCRIPTION
This PR corrects a typo in the `get_feature_names_out` method.