### PR TITLE
add inverse_transform functionality to sklearnTransformerWrapper

### DIFF
--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -129,10 +129,8 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
-        Apply the transformation to the dataframe.
+        Apply the reverse the transformation of a dataframe.
         Only the selected features will be modified.
-
-
 
         Args:
             X: Pandas DataFrame to perform desired transformation
@@ -143,28 +141,22 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
         # check that input is a dataframe
         X = _is_dataframe(X)
 
-        # Check that input data contains same number of columns as
-        # the dataframe used to fit the imputer.
-        _check_input_matches_training_df(X, self.input_shape_[1])
+        # A OneHotEncoder-transformed dataframe has the original variables.
+        if isinstance(self.transformer, OneHotEncoder):
+            X = X[self.variables]
 
-        try:
-            if isinstance(self.transformer, OneHotEncoder):
-                ohe_results_as_df = pd.DataFrame(
-                    data=self.transformer.inverse_transform(X[self.variables]),
-                    columns=self.transformer.get_feature_names(self.variables),
-                )
-                X = pd.concat([X, ohe_results_as_df], axis=1)
+        else:
+            # Check that input data contains same number of columns as
+            # the dataframe used to fit the imputer.
+            _check_input_matches_training_df(X, self.input_shape_[1])
+            X[self.variables] = (self
+                                 .transformer
+                                 .inverse_transform(X[self.variables])
+                                 )
+        return X
 
-            else:
-                X[self.variables] = (self
-                                     .transformer
-                                     .inverse_transform(X[self.variables])
-                                     )
-        except:
 
-        pass
-
-    def get_feature_names(self, X: pd.DataFrame) -> list:
+def get_feature_names(self, X: pd.DataFrame) -> list:
         """
 
 

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -129,14 +129,18 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
-        Apply the reverse the transformation of a dataframe.
+        Reverse the transformation of a dataframe.
         Only the selected features will be modified.
 
-        Args:
-            X: Pandas DataFrame to perform desired transformation
+        Parameters
+        ----------
+        X: pandas dataframe of shape = [n_samples, n_features]
+            A dataframe that has already been transformed using a
+            sklearn transformer.
 
         Returns:
-            Pandas DataFrame
+        X_new : pandas dataframe of shape = [n_samples, n_features]
+    
         """
         # check that input is a dataframe
         X = _is_dataframe(X)

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -140,7 +140,7 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
 
         Returns:
         X_new : pandas dataframe of shape = [n_samples, n_features]
-    
+
         """
         # check that input is a dataframe
         X = _is_dataframe(X)

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -125,3 +125,33 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
             X[self.variables] = self.transformer.transform(X[self.variables])
 
         return X
+
+
+    def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        """
+        Apply the transformation to the dataframe.
+        Only the selected features will be modified.
+
+
+
+        Args:
+            X: Pandas DataFrame to perform desired transformation
+
+        Returns:
+            Pandas DataFrame
+        """
+        pass
+
+    def get_feature_names(self, X:pd.DataFrame) -> list:
+        """
+
+
+
+        Args:
+            X: Pandas DataFrame to perform desired transformation
+
+        Returns:
+            List of column names
+        """
+
+        pass

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -140,9 +140,31 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
         Returns:
             Pandas DataFrame
         """
+        # check that input is a dataframe
+        X = _is_dataframe(X)
+
+        # Check that input data contains same number of columns as
+        # the dataframe used to fit the imputer.
+        _check_input_matches_training_df(X, self.input_shape_[1])
+
+        try:
+            if isinstance(self.transformer, OneHotEncoder):
+                ohe_results_as_df = pd.DataFrame(
+                    data=self.transformer.inverse_transform(X[self.variables]),
+                    columns=self.transformer.get_feature_names(self.variables),
+                )
+                X = pd.concat([X, ohe_results_as_df], axis=1)
+
+            else:
+                X[self.variables] = (self
+                                     .transformer
+                                     .inverse_transform(X[self.variables])
+                                     )
+        except:
+
         pass
 
-    def get_feature_names(self, X:pd.DataFrame) -> list:
+    def get_feature_names(self, X: pd.DataFrame) -> list:
         """
 
 
@@ -155,3 +177,13 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
         """
 
         pass
+
+    def _check_if_sklearn_method_exist(self):
+        """
+        Returns an error if sklearn does not have the desired method.
+
+        Args:
+
+        Returns:
+
+        """


### PR DESCRIPTION
Closes #371 

Notes from #371:


The sklearn transformer wrapper wraps an sklearn estimator to apply its functionality to a subset of variables and return a dataframe (instead of the default numpy array of sklearn).

We need to add the methods inverse_transform and get_feature_names out to this class.

Those methods would do whatever the sklearn transformer that is being wrapped does. So basically, we would be calling the methods from the sklearn transformer.

The thing is, not every sklearn transformer has those methods, and we don't know which transformer the user wants to wrap. So in the method we implement here we should check if the sklearn transformer has a callable inverse_transform or get_feature_names_out, then we return the method of the estimator. If not, we return a print statement, saying "the transformer does not have this method implemented" or something like that.
