### PR TITLE
time series forecasting: window features

### DIFF
--- a/feature_engine/timeseries/forecasting/window_features.py
+++ b/feature_engine/timeseries/forecasting/window_features.py
@@ -1,0 +1,41 @@
+# Authors: Morgan Sell <morganpsell@gmail.com>
+# License: BSD 3 clause
+
+from typing import List, Optional, Union
+
+import pandas as pd
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_is_fitted
+
+from feature_engine.dataframe_checks import (
+    _check_contains_inf,
+    _check_contains_na,
+    _check_input_matches_training_df,
+    _is_dataframe,
+)
+from feature_engine.docstrings import (
+    Substitution,
+    _drop_original_docstring,
+    _feature_names_in_docstring,
+    _fit_not_learn_docstring,
+    _fit_transform_docstring,
+    _missing_values_docstring,
+    _n_features_in_docstring,
+    _variables_numerical_docstring,
+)
+from feature_engine.validation import _return_tags
+from feature_engine.variable_manipulation import (
+    _check_input_parameter_variables,
+    _find_or_check_numerical_variables,
+)
+
+
+@Substitution(
+    variables=_variables_numerical_docstring,
+    missing_values=_missing_values_docstring,
+    drop_original=_drop_original_docstring,
+    feature_names_in_=_feature_names_in_docstring,
+    n_features_in_=_n_features_in_docstring,
+    fit=_fit_not_learn_docstring,
+    fit_transform=_fit_transform_docstring,
+)


### PR DESCRIPTION
Closes #343. 

Notes from #343:

The transformer should create computations over windows of past values of the features, and populate them at time t, t being the time of the forecast.

It uses pandas rolling, outputs several comptutations, mean, max, std, etc, and pandas shift to move the computations to the right row.

```
tmp = (data[variables]
       .rolling(window='3H').mean()  # Average the last 3 hr values.
       .shift(freq='1H')  # Move the average 1 step forward
       )

# Rename the columns
tmp.columns = [v + '_window' for v in variables]

data = data.merge(tmp, left_index=True, right_index=True, how='left')
```