### PR TITLE
Fix DropFeatures fail when features_to_drop is string, fixes issue 406

### DIFF
--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -58,9 +58,6 @@ class DropFeatures(BaseSelector):
                 "you wish to drop from the dataframe."
             )
 
-        if isinstance(features_to_drop, str):
-            features_to_drop = [features_to_drop]
-
         self.features_to_drop = features_to_drop
 
     def fit(self, X: pd.DataFrame, y: pd.Series = None):

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -52,9 +52,9 @@ class DropFeatures(BaseSelector):
 
     def __init__(self, features_to_drop: List[Union[str, int]]):
 
-        if not isinstance(features_to_drop, list) or len(features_to_drop) == 0:
+        if not isinstance(features_to_drop, (str, list)) or len(features_to_drop) == 0:
             raise ValueError(
-                "features_to_drop should be a list with the name of the variables"
+                "features_to_drop should be a list with the name of the variables "
                 "you wish to drop from the dataframe."
             )
 

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -58,6 +58,9 @@ class DropFeatures(BaseSelector):
                 "you wish to drop from the dataframe."
             )
 
+        if isinstance(features_to_drop, str):
+            features_to_drop = [features_to_drop]
+
         self.features_to_drop = features_to_drop
 
     def fit(self, X: pd.DataFrame, y: pd.Series = None):

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -54,8 +54,8 @@ class DropFeatures(BaseSelector):
 
         if not isinstance(features_to_drop, (str, list)) or len(features_to_drop) == 0:
             raise ValueError(
-                "features_to_drop should be a list with the name of the variables "
-                "you wish to drop from the dataframe."
+                f"features_to_drop should be a list with the name of the variables "
+                f"you wish to drop from the dataframe. Got {features_to_drop} instead."
             )
 
         self.features_to_drop = features_to_drop

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -4,6 +4,28 @@ import pytest
 from feature_engine.selection import DropFeatures
 
 
+def test_drop_1_variable(df_vartypes):
+    transformer = DropFeatures(features_to_drop="City")
+    X = transformer.fit_transform(df_vartypes)
+
+    # expected result
+    df = pd.DataFrame(
+        {
+            "Name": ["tom", "nick", "krish", "jack"],
+            "Age": [20, 21, 19, 18],
+            "Marks": [0.9, 0.8, 0.7, 0.6],
+            "dob": pd.date_range("2020-02-24", periods=4, freq="T"),
+        }
+    )
+
+    # init params
+    assert transformer.features_to_drop == ["City"]
+
+    # transform params
+    assert X.shape == (4, 4)
+    assert type(X) == pd.DataFrame
+    pd.testing.assert_frame_equal(X, df)
+
 def test_drop_2_variables(df_vartypes):
     transformer = DropFeatures(features_to_drop=["City", "dob"])
     X = transformer.fit_transform(df_vartypes)

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -26,6 +26,7 @@ def test_drop_1_variable(df_vartypes):
     assert type(X) == pd.DataFrame
     pd.testing.assert_frame_equal(X, df)
 
+
 def test_drop_2_variables(df_vartypes):
     transformer = DropFeatures(features_to_drop=["City", "dob"])
     X = transformer.fit_transform(df_vartypes)

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -19,7 +19,7 @@ def test_drop_1_variable(df_vartypes):
     )
 
     # init params
-    assert transformer.features_to_drop == ["City"]
+    assert transformer.features_to_drop == "City"
 
     # transform params
     assert X.shape == (4, 4)


### PR DESCRIPTION
Fix to issue #406 , where `DropFeatures` raises exception when instantiating with `features_to_drop` as string, even though docs and type hinting says string is supported.
