### PR TITLE
add check_y and check_x_y to check that indexes of X and y match when encoding

### DIFF
--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -89,7 +89,7 @@ def check_X(X: Union[np.generic, np.ndarray, pd.DataFrame]) -> pd.DataFrame:
 def check_y(
         y: Union[np.generic, np.ndarray, pd.Series, List],
         multi_output: bool = False,
-        y_numeric: bool = True,
+        y_numeric: bool = False,
 ) -> pd.Series:
     """
     Checks that y is a series, or alternatively, if it can be converted to a series.
@@ -117,7 +117,12 @@ def check_y(
         raise ValueError("y cannot be None.")
 
     elif isinstance(y, pd.Series):
-        _check_y(y, multi_output=multi_output, y_numeric=y_numeric)
+        if y.isnull().any():
+            raise ValueError("y contains NaN infinity values.")
+        if y.dtype != "O" and not np.isfinite(y).all():
+            raise ValueError("y contains infinity values.")
+        if y_numeric and y.dtype == "O":
+            y = y.astype("float")
         y = y.copy()
 
     else:

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -7,6 +7,7 @@ from typing import List, Union
 import numpy as np
 import pandas as pd
 from scipy.sparse import issparse
+from sklearn.utils.validation import _check_y
 
 
 def check_X(X: Union[np.generic, np.ndarray, pd.DataFrame]) -> pd.DataFrame:
@@ -83,6 +84,80 @@ def check_X(X: Union[np.generic, np.ndarray, pd.DataFrame]) -> pd.DataFrame:
         )
 
     return X
+
+
+def check_y(
+    y: Union[np.generic, np.ndarray, pd.Series, List],
+    multi_output: bool = False,
+    y_numeric: bool = True,
+) -> pd.Series:
+    """
+    Checks that y is a series, or alternatively, if it can be converted to a series.
+
+    Parameters
+    ----------
+    y : pd.Series, np.array, list
+
+    multi_output : bool, default=False
+        Whether to allow 2D y (array). If false, y will be
+        validated as a vector. y cannot have np.nan or np.inf values if
+        multi_output=True.
+
+    y_numeric : bool, default=False
+        Whether to ensure that y has a numeric type. If dtype of y is object,
+        it is converted to float64. Should only be used for regression
+        algorithms.
+
+    Returns
+    -------
+    y: pd.Series
+    """
+
+    if y is None:
+        raise ValueError("y cannot be None.")
+
+    elif isinstance(y, pd.Series):
+        _check_y(y, multi_output=multi_output, y_numeric=y_numeric)
+        y = y.copy()
+
+    else:
+        y = _check_y(y, multi_output=multi_output, y_numeric=y_numeric)
+        y = pd.Series(y)
+
+    return y
+
+
+def _check_pd_X_y(
+    X: Union[np.generic, np.ndarray, pd.DataFrame],
+    y: Union[np.generic, np.ndarray, pd.Series, List],
+    multi_output: bool = False,
+    y_numeric: bool = True,
+) -> (pd.DataFrame, pd.Series):
+    """
+    Ensures X and y are compatible pandas DataFrame and Series. If both are pandas
+    objects, checks that their indexes match. If any is a numpy array, converts to
+    pandas object with compatible index.
+
+    This transformer ensures that we can concatenate X and y using `pandas.concat`,
+    functionality needed in the encoders.
+
+    Parameters
+    ----------
+    X: Pandas DataFrame or numpy ndarray
+    y: Pandas Series or numpy ndarray
+
+    Raises
+    ------
+    ValueError: if X and y are pandas objects with inconsistent indexes.
+    TypeError: if X is sparse matrix, empty dataframe or not a dataframe.
+    TypeError: if y can't be parsed as pandas Series.
+
+    Returns
+    -------
+    X: Pandas DataFrame
+    y: Pandas Series
+    """
+    pass
 
 
 def _check_X_matches_training_df(X: pd.DataFrame, reference: int) -> None:

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -97,6 +97,7 @@ def check_y(
     Parameters
     ----------
     y : pd.Series, np.array, list
+        The input to check and copy or transform.
 
     multi_output : bool, default=False
         Whether to allow 2D y (array). If false, y will be
@@ -118,7 +119,7 @@ def check_y(
 
     elif isinstance(y, pd.Series):
         if y.isnull().any():
-            raise ValueError("y contains NaN infinity values.")
+            raise ValueError("y contains NaN values.")
         if y.dtype != "O" and not np.isfinite(y).all():
             raise ValueError("y contains infinity values.")
         if y_numeric and y.dtype == "O":
@@ -149,8 +150,10 @@ def check_X_y(
     Parameters
     ----------
     X: Pandas DataFrame or numpy ndarray
+        The input to check and copy or transform.
 
-    y: Pandas Series or numpy ndarray
+    y: pd.Series, np.array, list
+        The input to check and copy or transform.
 
     multi_output : bool, default=False
         Whether to allow 2D y (array). If false, y will be

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -136,7 +136,7 @@ def check_X_y(
         X: Union[np.generic, np.ndarray, pd.DataFrame],
         y: Union[np.generic, np.ndarray, pd.Series, List],
         multi_output: bool = False,
-        y_numeric: bool = True,
+        y_numeric: bool = False,
 ) -> Tuple[pd.DataFrame, pd.Series]:
     """
     Ensures X and y are compatible pandas DataFrame and Series. If both are pandas
@@ -149,7 +149,18 @@ def check_X_y(
     Parameters
     ----------
     X: Pandas DataFrame or numpy ndarray
+
     y: Pandas Series or numpy ndarray
+
+    multi_output : bool, default=False
+        Whether to allow 2D y (array). If false, y will be
+        validated as a vector. y cannot have np.nan or np.inf values if
+        multi_output=True.
+
+    y_numeric : bool, default=False
+        Whether to ensure that y has a numeric type. If dtype of y is object,
+        it is converted to float64. Should only be used for regression
+        algorithms.
 
     Raises
     ------

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -2,12 +2,12 @@
 transform().
 """
 
-from typing import List, Union
+from typing import List, Union, Tuple
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import issparse
-from sklearn.utils.validation import _check_y
+from sklearn.utils.validation import _check_y, check_consistent_length
 
 
 def check_X(X: Union[np.generic, np.ndarray, pd.DataFrame]) -> pd.DataFrame:
@@ -127,12 +127,12 @@ def check_y(
     return y
 
 
-def _check_pd_X_y(
+def check_X_y(
     X: Union[np.generic, np.ndarray, pd.DataFrame],
     y: Union[np.generic, np.ndarray, pd.Series, List],
     multi_output: bool = False,
     y_numeric: bool = True,
-) -> (pd.DataFrame, pd.Series):
+) -> Tuple[pd.DataFrame, pd.Series]:
     """
     Ensures X and y are compatible pandas DataFrame and Series. If both are pandas
     objects, checks that their indexes match. If any is a numpy array, converts to
@@ -157,7 +157,16 @@ def _check_pd_X_y(
     X: Pandas DataFrame
     y: Pandas Series
     """
-    pass
+    X = check_X(X)
+    y = check_y(y, multi_output=multi_output, y_numeric=y_numeric)
+    check_consistent_length(X, y)
+
+    # If X and y were a DataFrame and a Series, they are copied without transformation.
+    # Check that their indexes match.
+    if not all(y.index == X.index):
+        raise ValueError("The indexes of X and y do not match.")
+
+    return X, y
 
 
 def _check_X_matches_training_df(X: pd.DataFrame, reference: int) -> None:

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -138,8 +138,9 @@ class CountFrequencyEncoder(BaseCategorical):
         y: pandas Series, default = None
             y is not needed in this encoder. You can pass y or None.
         """
-
-        X = self._check_fit_input_and_variables(X)
+        X = self._check_X(X)
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         self.encoder_dict_ = {}
 

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -188,6 +188,7 @@ class DecisionTreeEncoder(BaseCategoricalTransformer):
             The target variable. Required to train the decision tree and for
             ordered ordinal encoding.
         """
+        X, y = self._check_X_y(X, y)
 
         # confirm model type and target variables are compatible.
         if self.regression is True:
@@ -201,8 +202,8 @@ class DecisionTreeEncoder(BaseCategoricalTransformer):
         else:
             check_classification_targets(y)
 
-        # check input dataframe
-        X = self._check_fit_input_and_variables(X)
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         if self.param_grid:
             param_grid = self.param_grid

--- a/feature_engine/encoding/mean_encoding.py
+++ b/feature_engine/encoding/mean_encoding.py
@@ -131,10 +131,9 @@ class MeanEncoder(BaseCategorical):
             The target.
         """
 
-        X = self._check_fit_input_and_variables(X)
-
-        if not isinstance(y, pd.Series):
-            y = pd.Series(y)
+        X, y = self._check_X_y(X, y)
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         temp = pd.concat([X, y], axis=1)
         temp.columns = list(X.columns) + ["target"]

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -180,7 +180,9 @@ class OneHotEncoder(BaseCategoricalTransformer):
             None.
         """
 
-        X = self._check_fit_input_and_variables(X)
+        X = self._check_X(X)
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         self.encoder_dict_ = {}
 

--- a/feature_engine/encoding/ordinal.py
+++ b/feature_engine/encoding/ordinal.py
@@ -146,16 +146,15 @@ class OrdinalEncoder(BaseCategorical):
             Otherwise, y needs to be passed when fitting the transformer.
         """
 
-        X = self._check_fit_input_and_variables(X)
-
-        # join target to predictor variables
         if self.encoding_method == "ordered":
-            if y is None:
-                raise ValueError("Please provide a target y for this encoding method")
+            X, y = self._check_X_y(X, y)
+        else:
+            X = self._check_X(X)
 
-            if not isinstance(y, pd.Series):
-                y = pd.Series(y)
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
+        if self.encoding_method == "ordered":
             temp = pd.concat([X, y], axis=1)
             temp.columns = list(X.columns) + ["target"]
 

--- a/feature_engine/encoding/probability_ratio.py
+++ b/feature_engine/encoding/probability_ratio.py
@@ -154,10 +154,7 @@ class PRatioEncoder(BaseCategorical):
             Target, must be binary.
         """
 
-        X = self._check_fit_input_and_variables(X)
-
-        if not isinstance(y, pd.Series):
-            y = pd.Series(y)
+        X, y = self._check_X_y(X, y)
 
         # check that y is binary
         if y.nunique() != 2:
@@ -165,6 +162,9 @@ class PRatioEncoder(BaseCategorical):
                 "This encoder is designed for binary classification. The target "
                 "used has more than 2 unique values."
             )
+
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         temp = pd.concat([X, y], axis=1)
         temp.columns = list(X.columns) + ["target"]

--- a/feature_engine/encoding/rare_label.py
+++ b/feature_engine/encoding/rare_label.py
@@ -147,7 +147,9 @@ class RareLabelEncoder(BaseCategoricalTransformer):
             y is not required. You can pass y or None.
         """
 
-        X = self._check_fit_input_and_variables(X)
+        X = self._check_X(X)
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         self.encoder_dict_ = {}
 

--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -136,10 +136,7 @@ class WoEEncoder(BaseCategorical):
             Target, must be binary.
         """
 
-        X = self._check_fit_input_and_variables(X)
-
-        if not isinstance(y, pd.Series):
-            y = pd.Series(y)
+        X, y = self._check_X_y(X, y)
 
         # check that y is binary
         if y.nunique() != 2:
@@ -147,6 +144,9 @@ class WoEEncoder(BaseCategorical):
                 "This encoder is designed for binary classification. The target "
                 "used has more than 2 unique values."
             )
+
+        self._check_or_select_variables(X)
+        self._get_feature_names_in(X)
 
         temp = pd.concat([X, y], axis=1)
         temp.columns = list(X.columns) + ["target"]

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -72,6 +72,11 @@ def test_check_y_raises_inf_error():
         check_y(s)
 
 
+def test_check_y_converts_string_to_number():
+    s = pd.Series(["0", "1", "2", "3", "4"])
+    assert_series_equal(check_y(s, y_numeric=True), s.astype("float"))
+
+
 def test_check_x_y_returns_pandas(df_vartypes):
     s = pd.Series([0, 1, 2, 3])
     x, y = check_X_y(df_vartypes, s)

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -79,6 +79,38 @@ def test_check_x_y_returns_pandas(df_vartypes):
     assert_series_equal(s, y)
 
 
+def test_check_X_y_pandas_non_typical_index():
+    df = pd.DataFrame(
+        {"0": [1, 2, 3, 4], "1": [5, 6, 7, 8]}, index=[22, 99, 101, 212]
+    )
+    s = pd.Series([1, 2, 3, 4], index=[22, 99, 101, 212])
+    x, y = check_X_y(df, s)
+    assert_frame_equal(df, x)
+    assert_series_equal(s, y)
+
+
+def test_check_x_y_reassings_index():
+    # case 1: X is dataframe, y is something else
+    df = pd.DataFrame(
+        {"0": [1, 2, 3, 4], "1": [5, 6, 7, 8]}, index=[22, 99, 101, 212]
+    )
+    s = np.array([1, 2, 3, 4])
+    s_exp = pd.Series([1, 2, 3, 4], index=[22, 99, 101, 212])
+    x, y = check_X_y(df, s)
+    assert_frame_equal(df, x)
+    assert_series_equal(s_exp.astype(int), y.astype(int))
+
+    # case 2: X is not a df, y is a series
+    df = np.array([[1, 2, 3, 4], [5, 6, 7, 8]]).T
+    s = pd.Series([1, 2, 3, 4], index=[22, 99, 101, 212])
+    df_exp = pd.DataFrame(df, columns=["0", "1"])
+    df_exp.index = s.index
+
+    x, y = check_X_y(df, s)
+    assert_frame_equal(df_exp, x)
+    assert_series_equal(s, y)
+
+
 def test_check_x_y_converts_numpy_to_pandas():
     a2D = np.array([[1, 2], [3, 4], [3, 4], [3, 4]])
     df_2D = pd.DataFrame(a2D, columns=["0", "1"])

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -9,6 +9,7 @@ from feature_engine.dataframe_checks import (
     _check_contains_na,
     _check_X_matches_training_df,
     check_X,
+    check_X_y,
     check_y,
 )
 
@@ -44,7 +45,7 @@ def test_raises_error_if_empty_df():
 
 
 def test_check_y_returns_series():
-    s = pd.Series([0,1,2,3,4])
+    s = pd.Series([0, 1, 2, 3, 4])
     assert_series_equal(check_y(s), s)
 
 
@@ -69,6 +70,45 @@ def test_check_y_raises_inf_error():
     s = pd.Series([0, np.inf, 2, 3, 4])
     with pytest.raises(ValueError):
         check_y(s)
+
+
+def test_check_x_y_returns_pandas(df_vartypes):
+    s = pd.Series([0, 1, 2, 3])
+    x, y = check_X_y(df_vartypes, s)
+    assert_frame_equal(df_vartypes, x)
+    assert_series_equal(s, y)
+
+
+def test_check_x_y_converts_numpy_to_pandas():
+    a2D = np.array([[1, 2], [3, 4], [3, 4], [3, 4]])
+    df_2D = pd.DataFrame(a2D, columns=["0", "1"])
+
+    a1D = np.array([1, 2, 3, 4])
+    s = pd.Series(a1D)
+
+    x, y = check_X_y(df_2D, s)
+    assert_frame_equal(df_2D, x)
+    assert_series_equal(s, y)
+
+
+def test_check_x_y_inconsistent_length(df_vartypes):
+    s = pd.Series([0, 1, 2, 3, 5])
+    with pytest.raises(ValueError):
+        check_X_y(df_vartypes, s)
+
+
+def test_check_x_y_raises_index_mismatch(df_vartypes):
+    s = pd.Series(
+        [
+            0,
+            1,
+            2,
+            3,
+        ],
+        index=[2, 3, 4, 5],
+    )
+    with pytest.raises(ValueError):
+        check_X_y(df_vartypes, s)
 
 
 def test_check_X_matches_training_df(df_vartypes):

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -89,6 +89,15 @@ def test_check_X_y_pandas_non_typical_index():
     assert_series_equal(s, y)
 
 
+def test_check_X_y_pandas_index_dont_match():
+    df = pd.DataFrame(
+        {"0": [1, 2, 3, 4], "1": [5, 6, 7, 8]}, index=[22, 99, 101, 212]
+    )
+    s = pd.Series([1, 2, 3, 4], index=[22, 99, 101, 999])
+    with pytest.raises(ValueError):
+        check_X_y(df, s)
+
+
 def test_check_x_y_reassings_index():
     # case 1: X is dataframe, y is something else
     df = pd.DataFrame(

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 from scipy.sparse import csr_matrix
 
 from feature_engine.dataframe_checks import (
@@ -9,6 +9,7 @@ from feature_engine.dataframe_checks import (
     _check_contains_na,
     _check_X_matches_training_df,
     check_X,
+    check_y,
 )
 
 
@@ -40,6 +41,34 @@ def test_raises_error_if_empty_df():
     df = pd.DataFrame([])
     with pytest.raises(ValueError):
         check_X(df)
+
+
+def test_check_y_returns_series():
+    s = pd.Series([0,1,2,3,4])
+    assert_series_equal(check_y(s), s)
+
+
+def test_check_y_converts_np_array():
+    a1D = np.array([1, 2, 3, 4])
+    s = pd.Series(a1D)
+    assert_series_equal(check_y(a1D), s)
+
+
+def test_check_y_raises_none_error():
+    with pytest.raises(ValueError):
+        check_y(None)
+
+
+def test_check_y_raises_nan_error():
+    s = pd.Series([0, np.nan, 2, 3, 4])
+    with pytest.raises(ValueError):
+        check_y(s)
+
+
+def test_check_y_raises_inf_error():
+    s = pd.Series([0, np.inf, 2, 3, 4])
+    with pytest.raises(ValueError):
+        check_y(s)
 
 
 def test_check_X_matches_training_df(df_vartypes):

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -77,14 +77,14 @@ def test_check_y_converts_string_to_number():
     assert_series_equal(check_y(s, y_numeric=True), s.astype("float"))
 
 
-def test_check_x_y_returns_pandas(df_vartypes):
+def test_check_x_y_returns_pandas_from_pandas(df_vartypes):
     s = pd.Series([0, 1, 2, 3])
     x, y = check_X_y(df_vartypes, s)
     assert_frame_equal(df_vartypes, x)
     assert_series_equal(s, y)
 
 
-def test_check_X_y_pandas_non_typical_index():
+def test_check_X_y_returns_pandas_from_pandas_with_non_typical_index():
     df = pd.DataFrame(
         {"0": [1, 2, 3, 4], "1": [5, 6, 7, 8]}, index=[22, 99, 101, 212]
     )
@@ -94,7 +94,7 @@ def test_check_X_y_pandas_non_typical_index():
     assert_series_equal(s, y)
 
 
-def test_check_X_y_pandas_index_dont_match():
+def test_check_X_y_raises_error_when_pandas_index_dont_match():
     df = pd.DataFrame(
         {"0": [1, 2, 3, 4], "1": [5, 6, 7, 8]}, index=[22, 99, 101, 212]
     )
@@ -103,7 +103,7 @@ def test_check_X_y_pandas_index_dont_match():
         check_X_y(df, s)
 
 
-def test_check_x_y_reassings_index():
+def test_check_x_y_reassings_index_when_only_one_input_is_pandas():
     # case 1: X is dataframe, y is something else
     df = pd.DataFrame(
         {"0": [1, 2, 3, 4], "1": [5, 6, 7, 8]}, index=[22, 99, 101, 212]
@@ -137,22 +137,8 @@ def test_check_x_y_converts_numpy_to_pandas():
     assert_series_equal(s, y)
 
 
-def test_check_x_y_inconsistent_length(df_vartypes):
+def test_check_x_y_raises_error_when_inconsistent_length(df_vartypes):
     s = pd.Series([0, 1, 2, 3, 5])
-    with pytest.raises(ValueError):
-        check_X_y(df_vartypes, s)
-
-
-def test_check_x_y_raises_index_mismatch(df_vartypes):
-    s = pd.Series(
-        [
-            0,
-            1,
-            2,
-            3,
-        ],
-        index=[2, 3, 4, 5],
-    )
     with pytest.raises(ValueError):
         check_X_y(df_vartypes, s)
 

--- a/tests/test_encoding/test_check_estimator_encoders.py
+++ b/tests/test_encoding/test_check_estimator_encoders.py
@@ -111,7 +111,7 @@ def test_check_estimator_from_feature_engine(estimator):
         ),
     ],
 )
-def test_fix_index_mismatch_from_x_numpy_y_pandas(encoder, df_test, df_expected):
+def test_encoders_when_x_numpy_y_pandas(encoder, df_test, df_expected):
     """
     Created 2022-03-27 to test fix to issue # 376
     Code adapted from:
@@ -190,7 +190,7 @@ def test_fix_index_mismatch_from_x_numpy_y_pandas(encoder, df_test, df_expected)
         ),
     ],
 )
-def test_fix_index_mismatch_from_x_pandas_y_numpy(encoder, df_test, df_expected):
+def test_encoders_when_x_pandas_y_numpy(encoder, df_test, df_expected):
     """
     Created 2022-03-27 to test fix to issue # 376
     Code adapted from:
@@ -250,7 +250,7 @@ def test_fix_index_mismatch_from_x_pandas_y_numpy(encoder, df_test, df_expected)
         ),
     ],
 )
-def test_detect_index_mismatch_from_x_pandas_y_pandas(encoder, df_test):
+def test_encoders_raise_error_when_x_pandas_y_pandas_index_mismatch(encoder, df_test):
     """
     Created 2022-03-27 to test fix to issue # 376
     """

--- a/tests/test_encoding/test_check_estimator_encoders.py
+++ b/tests/test_encoding/test_check_estimator_encoders.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 from sklearn.utils.estimator_checks import check_estimator
 
 from feature_engine.encoding import (
@@ -50,3 +51,217 @@ _estimators = [
 @pytest.mark.parametrize("estimator", _estimators)
 def test_check_estimator_from_feature_engine(estimator):
     return check_feature_engine_estimator(estimator)
+
+
+@pytest.mark.parametrize(
+    # Key to all: - "non-standard" index that is not the usual
+    # contiguous range starting a t 0
+    "encoder, df_test, df_expected",
+    [
+        (
+            DecisionTreeEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [21, 30, 21, 30, 51, 40]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"0": [25.5, 25.5, 25.5, 25.5, 45.5, 45.5]},
+            ),
+        ),
+        (
+            MeanEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"0": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]},
+            ),
+        ),
+        (
+            OrdinalEncoder(encoding_method="ordered"),
+            pd.DataFrame(
+                {
+                    "x": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+                    "y": [3, 3, 3, 2, 2, 2, 1, 1, 1],
+                },
+                index=[33, 5412, 66, 99, 334, 1212, 22, 555, 1],
+            ),
+            pd.DataFrame({"0": [2, 2, 2, 1, 1, 1, 0, 0, 0]}),
+        ),
+        (
+            PRatioEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"0": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]},
+            ),
+        ),
+        (
+            WoEEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"0": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]},
+            ),
+        ),
+    ],
+)
+def test_fix_index_mismatch_from_x_numpy_y_pandas(encoder, df_test, df_expected):
+    """
+    Created 2022-03-27 to test fix to issue # 376
+    Code adapted from:
+    https://github.com/scikit-learn-contrib/category_encoders/issues/280
+    """
+
+    X = df_test[["x"]]
+    y = df_test["y"]
+
+    # Test issue where X is array,
+    # y remains Series with original index
+    X_2 = X.to_numpy()
+    df_result = encoder.fit_transform(X_2, y)
+    assert df_result.equals(df_expected)
+
+
+@pytest.mark.parametrize(
+    # Key to all: - "non-standard" index that is not the usual
+    # contiguous range starting a t 0
+    "encoder, df_test, df_expected",
+    [
+        (
+            DecisionTreeEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [21, 30, 21, 30, 51, 40]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"x": [25.5, 25.5, 25.5, 25.5, 45.5, 45.5]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+        ),
+        (
+            MeanEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"x": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]}, index=[101, 105, 42, 76, 88, 92]
+            ),
+        ),
+        (
+            OrdinalEncoder(encoding_method="ordered"),
+            pd.DataFrame(
+                {
+                    "x": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+                    "y": [3, 3, 3, 2, 2, 2, 1, 1, 1],
+                },
+                index=[33, 5412, 66, 99, 334, 1212, 22, 555, 1],
+            ),
+            pd.DataFrame(
+                {"x": [2, 2, 2, 1, 1, 1, 0, 0, 0]},
+                index=[33, 5412, 66, 99, 334, 1212, 22, 555, 1],
+            ),
+        ),
+        (
+            PRatioEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"x": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]}, index=[101, 105, 42, 76, 88, 92]
+            ),
+        ),
+        (
+            WoEEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+            pd.DataFrame(
+                {"x": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}, index=[101, 105, 42, 76, 88, 92]
+            ),
+        ),
+    ],
+)
+def test_fix_index_mismatch_from_x_pandas_y_numpy(encoder, df_test, df_expected):
+    """
+    Created 2022-03-27 to test fix to issue # 376
+    Code adapted from:
+    https://github.com/scikit-learn-contrib/category_encoders/issues/280
+    """
+
+    X = df_test[["x"]]
+    y = df_test["y"]
+
+    # Test issue fix where X becomes array,
+    # y remains Series with original DataFrame index
+    y_2 = y.to_numpy()
+    df_result = encoder.fit_transform(X, y_2)
+    assert df_result.equals(df_expected)
+
+
+@pytest.mark.parametrize(
+    "encoder, df_test",
+    [
+        (
+            DecisionTreeEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [21, 30, 21, 30, 51, 40]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+        ),
+        (
+            MeanEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+        ),
+        (
+            OrdinalEncoder(encoding_method="ordered"),
+            pd.DataFrame(
+                {
+                    "x": ["a", "a", "a", "b", "b", "b", "c", "c", "c"],
+                    "y": [3, 3, 3, 2, 2, 2, 1, 1, 1],
+                },
+                index=[33, 5412, 66, 99, 334, 1212, 22, 555, 1],
+            ),
+        ),
+        (
+            PRatioEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+        ),
+        (
+            WoEEncoder(),
+            pd.DataFrame(
+                {"x": ["a", "a", "b", "b", "c", "c"], "y": [1, 0, 1, 0, 1, 0]},
+                index=[101, 105, 42, 76, 88, 92],
+            ),
+        ),
+    ],
+)
+def test_detect_index_mismatch_from_x_pandas_y_pandas(encoder, df_test):
+    """
+    Created 2022-03-27 to test fix to issue # 376
+    """
+
+    X: pd.DataFrame = df_test[["x"]]
+    y: pd.Series = df_test["y"]
+
+    # Test issue fix where indexes of pandas objects are mismatched
+    y = y.reset_index(drop=True)
+
+    e: Exception
+    with pytest.raises(Exception) as e:
+        encoder.fit_transform(X, y)
+    assert "indexes" in e.value.args[0].lower()


### PR DESCRIPTION
closes #377 
closes #376 
closes #365 

@noahjgreen295 @bmreiniger

I am bringing the changes from #377 to this new PR at the back of former PR #408

Regarding the X and y checks, I am bringing in sklearn functionality to check y and then to check X and y (taken from their check_X_y function). I think that decreases the amount of new things we need to code.

I think I captured most of what we discussed in #377 , and I brought forward the tests and ideas from @noahjgreen295 as they were or slightly reformatted and also the suggestions from @bmreiniger.

Would you guys have a look and let me know what you think?

Let me know if you are OK to merge.

Thank you so much for raising and also for the support on this issue.