### PR TITLE
Fix typo in documentation code sample of ArbitraryNumberImputer

### DIFF
--- a/docs/user_guide/imputation/ArbitraryNumberImputer.rst
+++ b/docs/user_guide/imputation/ArbitraryNumberImputer.rst
@@ -34,7 +34,7 @@ with 99 like this:
 .. code-block:: python
 
     transformer = ArbitraryNumberImputer(
-            imputer_dict = {'varA' : 1, 'varB': 99]
+            imputer_dict = {'varA' : 1, 'varB': 99}
             )
 
     Xt = transformer.fit_transform(X)


### PR DESCRIPTION
Thanks for a great library! 

Noticed a small typo while reading the docs.