### PR TITLE
Added FunctionTransformer test and wrap refenrece

### DIFF
--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -215,6 +215,7 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
             "OneHotEncoder",
             "OrdinalEncoder",
             "SimpleImputer",
+            "FunctionTransformer",
         ]:
             self.variables_ = _find_all_variables(X, self.variables)
 

--- a/tests/test_selection/test_check_estimator_selectors.py
+++ b/tests/test_selection/test_check_estimator_selectors.py
@@ -2,12 +2,6 @@ import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.utils.estimator_checks import check_estimator
 
-from tests.estimator_checks.estimator_checks import (
-    check_feature_engine_estimator,
-)
-from tests.estimator_checks.init_params_triggered_functionality_checks import (
-    check_confirm_variables,
-)
 from feature_engine.selection import (
     DropConstantFeatures,
     DropCorrelatedFeatures,
@@ -20,6 +14,10 @@ from feature_engine.selection import (
     SelectBySingleFeaturePerformance,
     SelectByTargetMeanPerformance,
     SmartCorrelatedSelection,
+)
+from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.init_params_triggered_functionality_checks import (
+    check_confirm_variables,
 )
 
 _logreg = LogisticRegression(C=0.0001, max_iter=2, random_state=1)

--- a/tests/test_selection/test_check_estimator_selectors.py
+++ b/tests/test_selection/test_check_estimator_selectors.py
@@ -2,6 +2,12 @@ import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.utils.estimator_checks import check_estimator
 
+from tests.estimator_checks.estimator_checks import (
+    check_feature_engine_estimator,
+)
+from tests.estimator_checks.init_params_triggered_functionality_checks import (
+    check_confirm_variables,
+)
 from feature_engine.selection import (
     DropConstantFeatures,
     DropCorrelatedFeatures,
@@ -14,10 +20,6 @@ from feature_engine.selection import (
     SelectBySingleFeaturePerformance,
     SelectByTargetMeanPerformance,
     SmartCorrelatedSelection,
-)
-from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
-from tests.estimator_checks.init_params_triggered_functionality_checks import (
-    check_confirm_variables,
 )
 
 _logreg = LogisticRegression(C=0.0001, max_iter=2, random_state=1)

--- a/tests/test_wrappers/test_sklearn_wrapper.py
+++ b/tests/test_wrappers/test_sklearn_wrapper.py
@@ -549,3 +549,25 @@ def test_get_feature_names_out_ohe(varlist, df_vartypes):
         ]
 
         assert output_feat == transformer.get_feature_names_out(varlist)
+
+
+def test_sklearn_transformer_wrapper():
+    X = pd.DataFrame({
+        "col1": ["1", "2", "3"],
+        "col2": ["a", "b", "c"]
+        })
+
+    X_expected = pd.DataFrame({
+        "col1": [1.0, 2.0, 3.0],
+        "col2": ["a", "b", "c"]
+        })
+
+    transformer = SklearnTransformerWrapper(
+        FunctionTransformer(lambda x: x.astype(np.float64)),
+        variables=["col1"]
+    )
+
+    X_tf = transformer.fit_transform(X)
+
+    pd.testing.assert_frame_equal(X_expected, X_tf)
+    

--- a/tests/test_wrappers/test_sklearn_wrapper.py
+++ b/tests/test_wrappers/test_sklearn_wrapper.py
@@ -552,22 +552,14 @@ def test_get_feature_names_out_ohe(varlist, df_vartypes):
 
 
 def test_sklearn_transformer_wrapper():
-    X = pd.DataFrame({
-        "col1": ["1", "2", "3"],
-        "col2": ["a", "b", "c"]
-        })
+    X = pd.DataFrame({"col1": ["1", "2", "3"], "col2": ["a", "b", "c"]})
 
-    X_expected = pd.DataFrame({
-        "col1": [1.0, 2.0, 3.0],
-        "col2": ["a", "b", "c"]
-        })
+    X_expected = pd.DataFrame({"col1": [1.0, 2.0, 3.0], "col2": ["a", "b", "c"]})
 
     transformer = SklearnTransformerWrapper(
-        FunctionTransformer(lambda x: x.astype(np.float64)),
-        variables=["col1"]
+        FunctionTransformer(lambda x: x.astype(np.float64)), variables=["col1"]
     )
 
     X_tf = transformer.fit_transform(X)
 
     pd.testing.assert_frame_equal(X_expected, X_tf)
-    


### PR DESCRIPTION
Issue: #416

This PR modifies:

`feature_engine/feature_engine/wrappers/wrappers.py`
`feature_engine/tests/test_wrappers/test_sklearn_wrapper.py`


Passed `pytest tests/test_wrappers/test_sklearn_wrapper.py -k 'test_sklearn_transformer_wrapper'` test successfully :

```{bash}
================================================================= warnings summary ==================================================================
<frozen importlib._bootstrap>:219
<frozen importlib._bootstrap>:219
<frozen importlib._bootstrap>:219
  <frozen importlib._bootstrap>:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 216 from C header, got 232 from PyObject

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 1 passed, 68 deselected, 3 warnings in 0.44s ====================================================
```
 