### PR TITLE
(In progress) Backoff binning rare labels in CountFrequency encoder

### DIFF
--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -148,6 +148,9 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
 
         y: pandas Series, default = None
             y is not needed in this encoder. You can pass y or None.
+
+        threshold : list of floats
+            Thresholds for each column needed for binning rare categories
         """
         X = check_X(X)
         self._check_or_select_variables(X)
@@ -158,7 +161,6 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
         if not isinstance(threshold, list):
             threshold = [None] * len(self.variables_)
 
-        # print(self.variables_)
         # learn encoding maps
         for var, threshold in zip(self.variables_, threshold):
 

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -176,7 +176,7 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
         y: pandas Series, default = None
             y is not needed in this encoder. You can pass y or None.
 
-        threshold : int if encoding is "count", 
+        threshold : int if encoding is "count",
                     float if encoding is "frequency", default = None
             Thresholds for each column needed for binning infrequent categories
         """
@@ -255,7 +255,7 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
                     .map(self.encoder_dict_[feature])
                 )
             return X
-        
+
     def inverse_transform(self, X: pd.DataFrame):
         """inverse_transform is not implemented for this transformer."""
         return self

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -179,6 +179,7 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
         threshold : int/float if encoding is "count" and "frequency", default = None
             Thresholds for each column needed for binning infrequent categories
         """
+
         X = check_X(X)
         self._check_or_select_variables(X)
         self._get_feature_names_in(X)

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -80,7 +80,7 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
 
     threshold: int,float or None, default=None
         With threshold you have the option to perform backoff binning for all
-        columns for the given threshold.
+        columns based on the given threshold.
 
     Attributes
     ----------
@@ -176,8 +176,9 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
         y: pandas Series, default = None
             y is not needed in this encoder. You can pass y or None.
 
-        threshold : list of floats
-            Thresholds for each column needed for binning rare categories
+        threshold : int if encoding is "count", 
+                    float if encoding is "frequency", default = None
+            Thresholds for each column needed for binning infrequent categories
         """
         X = check_X(X)
         self._check_or_select_variables(X)
@@ -254,3 +255,7 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
                     .map(self.encoder_dict_[feature])
                 )
             return X
+        
+    def inverse_transform(self, X: pd.DataFrame):
+        """inverse_transform is not implemented for this transformer."""
+        return self

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -176,8 +176,7 @@ class CountFrequencyEncoder(CategoricalInitExpandedMixin, CategoricalMethodsMixi
         y: pandas Series, default = None
             y is not needed in this encoder. You can pass y or None.
 
-        threshold : int if encoding is "count",
-                    float if encoding is "frequency", default = None
+        threshold : int/float if encoding is "count" and "frequency", default = None
             Thresholds for each column needed for binning infrequent categories
         """
         X = check_X(X)

--- a/tests/test_encoding/test_count_frequency_encoder.py
+++ b/tests/test_encoding/test_count_frequency_encoder.py
@@ -255,3 +255,87 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
 def test_error_if_rare_labels_not_permitted_value():
     with pytest.raises(ValueError):
         CountFrequencyEncoder(errors="empanada")
+
+
+def test_error_if_incorrect_threshold_value_for_encoding_is_count():
+    with pytest.raises(ValueError):
+        CountFrequencyEncoder(encoding_method="count", threshold=0.75)
+
+
+def test_error_if_incorrect_threshold_value_for_encoding_is_frequency():
+    with pytest.raises(ValueError):
+        CountFrequencyEncoder(encoding_method="frequency", threshold=105)
+
+
+def test_error_if_incorrect_threshold_type_for_encoding_is_count():
+    with pytest.raises(ValueError):
+        CountFrequencyEncoder(encoding_method="count", threshold=[15, 25, 54])
+
+
+def test_error_if_incorrect_threshold_type_for_encoding_is_frequency():
+    with pytest.raises(ValueError):
+        CountFrequencyEncoder(encoding_method="frequency", threshold=[1.5, None, 54])
+
+
+def test_threshold_encode_all_variables_ignore_format_with_counts(df_enc):
+    # test case : all categorical and numerical variables with counts
+    encoder = CountFrequencyEncoder(
+        encoding_method="count",
+        ignore_format=True,
+        variables=["var_A", "var_B", "target"],
+        threshold=6,
+    )
+    encoder.fit_transform(df_enc)
+
+    # expected result
+    # print(df_enc['var_A'].value_counts().to_dict())
+    # print(df_enc['var_B'].value_counts().to_dict())
+    # print(df_enc['target'].value_counts().to_dict())
+
+    # print(encoder.encoder_dict_)
+    assert encoder.encoder_dict_ == {
+        "var_A": {"backoff_bin": 10, "B": 10},
+        "var_B": {"backoff_bin": 10, "A": 10},
+        "target": {"backoff_bin": 6, 0: 14},
+    }
+
+
+def test_threshold_encode_all_variables_without_ignore_format_with_counts(df_enc):
+    # test case : all categorical variables with counts
+    encoder = CountFrequencyEncoder(
+        encoding_method="count",
+        ignore_format=False,
+        variables=None,
+        threshold=6,
+    )
+    encoder.fit_transform(df_enc)
+
+    # expected result
+    # print(df_enc['var_A'].value_counts().to_dict())
+    # print(df_enc['var_B'].value_counts().to_dict())
+    # print(df_enc['target'].value_counts().to_dict())
+
+    # print(encoder.encoder_dict_)
+    assert encoder.encoder_dict_ == {
+        "var_A": {"backoff_bin": 10, "B": 10},
+        "var_B": {"backoff_bin": 10, "A": 10},
+    }
+
+
+def test_automatically_encode_all_variables_without_ignore_format_with_frequency(
+    df_enc,
+):
+    # test case :  all categorical variables with frequency
+    encoder = CountFrequencyEncoder(
+        encoding_method="frequency", variables=None, threshold=0.3
+    )
+    encoder.fit_transform(df_enc)
+
+    print((df_enc["var_A"].value_counts() / len(df_enc)).to_dict())
+    print((df_enc["var_B"].value_counts() / len(df_enc)).to_dict())
+    print((df_enc["target"].value_counts() / len(df_enc)).to_dict())
+    print(encoder.encoder_dict_)
+    assert encoder.encoder_dict_ == {
+        "var_A": {"backoff_bin": 0.5, "B": 0.5},
+        "var_B": {"backoff_bin": 0.5, "A": 0.5},
+    }

--- a/tests/test_encoding/test_count_frequency_encoder.py
+++ b/tests/test_encoding/test_count_frequency_encoder.py
@@ -257,42 +257,42 @@ def test_error_if_rare_labels_not_permitted_value():
         CountFrequencyEncoder(errors="empanada")
 
 
-def test_error_if_incorrect_threshold_value_for_encoding_is_count():
+def test_error_if_incorrect_threshold_value_for_encoding_count():
     with pytest.raises(ValueError):
         CountFrequencyEncoder(encoding_method="count", threshold=0.75)
 
 
-def test_error_if_incorrect_threshold_value_for_encoding_is_frequency():
+def test_error_if_incorrect_threshold_value_for_encoding_frequency():
     with pytest.raises(ValueError):
         CountFrequencyEncoder(encoding_method="frequency", threshold=105)
 
 
-def test_error_if_incorrect_threshold_type_for_encoding_is_count():
+def test_error_if_incorrect_threshold_type_for_encoding_count():
     with pytest.raises(ValueError):
         CountFrequencyEncoder(encoding_method="count", threshold=[15, 25, 54])
 
 
-def test_error_if_incorrect_threshold_type_for_encoding_is_frequency():
+def test_error_if_incorrect_threshold_type_for_encoding_frequency():
     with pytest.raises(ValueError):
         CountFrequencyEncoder(encoding_method="frequency", threshold=[1.5, None, 54])
 
 
 def test_threshold_encode_all_variables_ignore_format_with_counts(df_enc):
-    # test case : all categorical and numerical variables with counts
+    # test case : all variables with counts
     encoder = CountFrequencyEncoder(
         encoding_method="count",
         ignore_format=True,
-        variables=["var_A", "var_B", "target"],
+        variables=None,
         threshold=6,
     )
+    # init params
+    assert encoder.encoding_method == "count"
+    assert encoder.variables is None
+    assert isinstance(encoder.threshold, int)
+    # fit params
+
     encoder.fit_transform(df_enc)
 
-    # expected result
-    # print(df_enc['var_A'].value_counts().to_dict())
-    # print(df_enc['var_B'].value_counts().to_dict())
-    # print(df_enc['target'].value_counts().to_dict())
-
-    # print(encoder.encoder_dict_)
     assert encoder.encoder_dict_ == {
         "var_A": {"backoff_bin": 10, "B": 10},
         "var_B": {"backoff_bin": 10, "A": 10},
@@ -308,14 +308,15 @@ def test_threshold_encode_all_variables_without_ignore_format_with_counts(df_enc
         variables=None,
         threshold=6,
     )
+
+    # init params
+    assert encoder.encoding_method == "count"
+    assert encoder.variables is None
+    assert isinstance(encoder.threshold, int)
+    # fit params
+
     encoder.fit_transform(df_enc)
 
-    # expected result
-    # print(df_enc['var_A'].value_counts().to_dict())
-    # print(df_enc['var_B'].value_counts().to_dict())
-    # print(df_enc['target'].value_counts().to_dict())
-
-    # print(encoder.encoder_dict_)
     assert encoder.encoder_dict_ == {
         "var_A": {"backoff_bin": 10, "B": 10},
         "var_B": {"backoff_bin": 10, "A": 10},
@@ -327,15 +328,38 @@ def test_automatically_encode_all_variables_without_ignore_format_with_frequency
 ):
     # test case :  all categorical variables with frequency
     encoder = CountFrequencyEncoder(
-        encoding_method="frequency", variables=None, threshold=0.3
+        encoding_method="frequency", ignore_format=False, variables=None, threshold=0.3
     )
-    encoder.fit_transform(df_enc)
 
-    print((df_enc["var_A"].value_counts() / len(df_enc)).to_dict())
-    print((df_enc["var_B"].value_counts() / len(df_enc)).to_dict())
-    print((df_enc["target"].value_counts() / len(df_enc)).to_dict())
-    print(encoder.encoder_dict_)
+    # init params
+    assert encoder.encoding_method == "frequency"
+    assert encoder.variables is None
+    assert isinstance(encoder.threshold, float)
+    # fit params
+
+    encoder.fit_transform(df_enc)
     assert encoder.encoder_dict_ == {
         "var_A": {"backoff_bin": 0.5, "B": 0.5},
         "var_B": {"backoff_bin": 0.5, "A": 0.5},
+    }
+
+
+def test_automatically_encode_all_variables_with_ignore_format_with_frequency(
+    df_enc,
+):
+    # test case :  all variables with frequency
+    encoder = CountFrequencyEncoder(
+        encoding_method="frequency", ignore_format=True, variables=None, threshold=0.3
+    )
+    # init params
+    assert encoder.encoding_method == "frequency"
+    assert encoder.variables is None
+    assert isinstance(encoder.threshold, float)
+    # fit params
+    encoder.fit_transform(df_enc)
+
+    assert encoder.encoder_dict_ == {
+        "var_A": {"backoff_bin": 0.5, "B": 0.5},
+        "var_B": {"backoff_bin": 0.5, "A": 0.5},
+        "target": {"backoff_bin": 0.3, 0: 0.7},
     }


### PR DESCRIPTION
**Reference Issues/PRs**:
Issue : #429  (Add functionality for threshold)

**What does this implement/fix?**
Adds functionality to group categories with few observations.

Hi, @solegalli I've added functionality for Backoff binning, threshold is a list that takes values(threshold) for each feature mentioned and bins them accordingly. I haven't added the tests yet but will add them.

Please let me know any improvements that you think could be done here. I'll implement them.