### PR TITLE
Create check_y_is_binary() check. Use in transformers in which the dependent variable must be binary.

### DIFF
--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -2,7 +2,7 @@
 transform().
 """
 
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -279,6 +279,7 @@ def _check_contains_inf(X: pd.DataFrame, variables: List[Union[str, int]]) -> No
     ------
     ValueError
         If the variable(s) contain np.inf values
+
     """
 
     if np.isinf(X[variables]).values.any():
@@ -288,7 +289,7 @@ def _check_contains_inf(X: pd.DataFrame, variables: List[Union[str, int]]) -> No
         )
 
 
-def check_y_is_binary(y: pd.Series) -> None:
+def _check_y_is_binary(y: pd.Series) -> None:
     """
      Checks y, dependent variable, is binary
 
@@ -300,10 +301,16 @@ def check_y_is_binary(y: pd.Series) -> None:
     Raises
     ------
     ValueError
-        If the series has values other than 0 or 1
-
+        If the data series has values other than 0 or 1.
 
     """
     # TODO: Should the check raise an error if y is only 0s or only 1s?
 
-    pass
+    binary_values = [0, 1]
+    unique_values = list(y.unique())
+
+    if not all(val in unique_values for val in binary_values):
+        raise ValueError(
+            "y must be a binary variable comprised only of 0s and 1. "
+            f"Got {unique_values} instead."
+        )

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -286,3 +286,24 @@ def _check_contains_inf(X: pd.DataFrame, variables: List[Union[str, int]]) -> No
             "Some of the variables to transform contain inf values. Check and "
             "remove those before using this transformer."
         )
+
+
+def check_y_is_binary(y: pd.Series) -> None:
+    """
+     Checks y, dependent variable, is binary
+
+    Parameters
+    ----------
+    y : Pandas Series
+        The dataset's series of dependent or predicted variables
+
+    Raises
+    ------
+    ValueError
+        If the series has values other than 0 or 1
+
+
+    """
+    # TODO: Should the check raise an error if y is only 0s or only 1s?
+
+    pass

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -7,6 +7,7 @@ from typing import List, Union, Tuple
 import numpy as np
 import pandas as pd
 from scipy.sparse import issparse
+from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _check_y, check_consistent_length
 
 
@@ -303,14 +304,24 @@ def _check_y_is_binary(y: pd.Series) -> None:
     ValueError
         If the data series has values other than 0 or 1.
 
+    Returns
+    _______
+    y : Pandas Series
+        The dataset's series of dependent or predicted variables.
+        If unique labels are not 0 and 1, function transform binary
+        variables 0 and 1.
+
     """
-    # TODO: Should the check raise an error if y is only 0s or only 1s?
 
-    binary_values = [0, 1]
-    unique_values = list(y.unique())
-
-    if not all(val in binary_values for val in unique_values):
+    if type_of_target(y) != "binary":
         raise ValueError(
             "y must be a binary variable comprised only of 0s and 1. "
-            f"Got {unique_values} instead."
+            f"Got {type_of_target(y)} instead."
         )
+
+    else:
+        # transform class labels to 0 and 1, if not already
+        if any(label for label in y.unique() if label not in [0, 1]):
+            y = pd.Series(np.where(y == y.unique()[0], 0, 1))
+
+    return y

--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -309,7 +309,7 @@ def _check_y_is_binary(y: pd.Series) -> None:
     binary_values = [0, 1]
     unique_values = list(y.unique())
 
-    if not all(val in unique_values for val in binary_values):
+    if not all(val in binary_values for val in unique_values):
         raise ValueError(
             "y must be a binary variable comprised only of 0s and 1. "
             f"Got {unique_values} instead."

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -8,6 +8,7 @@ from feature_engine.dataframe_checks import (
     _check_contains_inf,
     _check_contains_na,
     _check_X_matches_training_df,
+    _check_y_is_binary,
     check_X,
     check_X_y,
     check_y,
@@ -151,3 +152,14 @@ def test_contains_inf(df_na):
     df_na.fillna(np.inf, inplace=True)
     with pytest.raises(ValueError):
         assert _check_contains_inf(df_na, ["Age", "Marks"])
+
+
+@pytest.mark.parametrize("_variables",
+                         [0, 1, 0, 3, 2, 2],
+                         [1, 2, 1, 1, 2],
+                         ["one", "one", "one"],
+                         )
+def test_check_y_is_binary_not_permitted_values(_variables):
+    with pytest.raises(ValueError):
+        _check_y_is_binary(pd.Series(_variables))
+

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -164,4 +164,3 @@ def test_contains_inf(df_na):
 def test_check_y_is_binary_not_permitted_values(_variables):
     with pytest.raises(ValueError):
         _check_y_is_binary(pd.Series(_variables))
-

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -154,14 +154,15 @@ def test_contains_inf(df_na):
         assert _check_contains_inf(df_na, ["Age", "Marks"])
 
 
-@pytest.mark.parametrize("_variables",
-                         [
-                             [0, 1, 0, 3, 2, 2],
-                             [0.9, 0.9, -0.1, -0.1, 0.9],
-                             ["one", "two", "three"],
-                             [[1, 1], [0, 1], [0, 0], [1,0]]
-                         ]
-                         )
+@pytest.mark.parametrize(
+    "_variables",
+    [
+        [0, 1, 0, 3, 2, 2],
+        [0.9, 0.9, -0.1, -0.1, 0.9],
+        ["one", "two", "three"],
+        [[1, 1], [0, 1], [0, 0], [1, 0]],
+    ],
+)
 def test_check_y_is_binary_not_permitted_values(_variables):
     with pytest.raises(ValueError):
         _check_y_is_binary(pd.Series(_variables))

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -155,9 +155,11 @@ def test_contains_inf(df_na):
 
 
 @pytest.mark.parametrize("_variables",
-                         [0, 1, 0, 3, 2, 2],
-                         [1, 2, 1, 1, 2],
-                         ["one", "one", "one"],
+                         [
+                             [0, 1, 0, 3, 2, 2],
+                             [1, 2, 1, 1, 2],
+                             ["one", "one", "one"],
+                         ]
                          )
 def test_check_y_is_binary_not_permitted_values(_variables):
     with pytest.raises(ValueError):

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -157,10 +157,31 @@ def test_contains_inf(df_na):
 @pytest.mark.parametrize("_variables",
                          [
                              [0, 1, 0, 3, 2, 2],
-                             [1, 2, 1, 1, 2],
-                             ["one", "one", "one"],
+                             [0.9, 0.9, -0.1, -0.1, 0.9],
+                             ["one", "two", "three"],
+                             [[1, 1], [0, 1], [0, 0], [1,0]]
                          ]
                          )
 def test_check_y_is_binary_not_permitted_values(_variables):
     with pytest.raises(ValueError):
         _check_y_is_binary(pd.Series(_variables))
+
+
+def test_check_y_is_binary_transform_values():
+    # test 1
+    y = pd.Series([1, 2, 1, 2, 2, 2, 1])
+    result = _check_y_is_binary(y)
+    expected_result = pd.Series([0, 1, 0, 1, 1, 1, 0])
+    assert result.equals(expected_result)
+
+    # test 2
+    y = pd.Series(["a", "b", "b", "a", "a", "a", "b"])
+    result = _check_y_is_binary(y)
+    expected_result = pd.Series([0, 1, 1, 0, 0, 0, 1])
+    assert result.equals(expected_result)
+
+    # test 3 - no transform
+    y = pd.Series([1, 1, 1, 0, 0, 1, 1])
+    result = _check_y_is_binary(y)
+    expected_result = pd.Series([1, 1, 1, 0, 0, 1, 1])
+    assert result.equals(expected_result)


### PR DESCRIPTION
Closes #413 

Notes from #413:

Many transformers in feature engine require that y is binary. At the moment we do this check within each transformer. We should create a function that unifies this behaviour and call it from the transformers instead of repeating all the logic every time.

Example: encoders woe, pratio
