### PR TITLE
fix Sklearnwrapper output for OneHotEncoder and PolynomialFeatures to avoid duplicated features

### DIFF
--- a/docs/user_guide/wrappers/Wrapper.rst
+++ b/docs/user_guide/wrappers/Wrapper.rst
@@ -116,7 +116,11 @@ to select only a subset of the variables.
     X_train_t = selector.transform(X_train.fillna(0))
     X_test_t = selector.transform(X_test.fillna(0))
 
-Even though Feature Engine has its own implementation of OneHotEncoder, you may want to use Scikit-Learn Implementation in order to access different options, such as drop first Category.
+Even though Feature-engine has its own implementation of OneHotEncoder, you may want 
+to use Scikit-Learn's transformer in order to access different options, 
+such as drop first Category. 
+In the following example, we show you how to apply Scikit-learn's OneHotEncoder to a 
+subset of categories using the :class:SklearnTransformerWrapper().
 
 .. code:: python
 
@@ -126,19 +130,39 @@ Even though Feature Engine has its own implementation of OneHotEncoder, you may 
     from sklearn.preprocessing import OneHotEncoder
 
     df = pd.read_csv('https://www.openml.org/data/get_csv/16826755/phpMYEkMl')
-    X = df[['pclass']]
+    X = df
     y = df.survived
     X_train, X_test, y_train, y_test= train_test_split(X, y, test_size=0.2, random_state=42)
 
-    ohe = SklearnTransformerWrapper(OneHotEncoder(sparse=False, drop='first'))
+    ohe = SklearnTransformerWrapper(OneHotEncoder(sparse=False, drop='first'), variables = ['pclass','sex'])
 
     ohe.fit(X_train)
 
     X_train_transformed = ohe.transform(X_train)
     X_test_transformed = ohe.transform(X_test)
 
+    print(X_train_transformed.head())
+          age   fare     embarked  pclass_2  pclass_3  sex_male
+    772   17   7.8958        S       0.0       1.0       1.0
+    543   36     10.5        S       1.0       0.0       1.0
+    289   18    79.65        S       0.0       0.0       0.0
+    10    47  227.525        C       0.0       0.0       1.0
+    147  NaN     42.4        S       0.0       0.0       1.0
 
-Let's say you want to use :class:`SklearnTransformerWrapper()` in a more complex context. As you may note there are `?` signs to denote unknown values. Due to the complexity of the transformations needed we'll use a Pipeline to impute missing values, encode categorical features and create interactions for specific variables using Scikit-Learn PolynomialFeatures.
+    print(X_test_transformed.head())
+          age   fare      embarked  pclass_2  pclass_3  sex_male
+    1148   35    7.125        S       0.0       1.0       1.0
+    1049   20  15.7417        C       0.0       1.0       1.0
+    982   NaN   7.8958        S       0.0       1.0       1.0
+    808   NaN     8.05        S       0.0       1.0       1.0
+    1195  NaN     7.75        Q       0.0       1.0       1.0
+
+
+Let's say you want to use :class:`SklearnTransformerWrapper()` in a more complex 
+context. As you may note there are `?` signs to denote unknown values. Due to the 
+complexity of the transformations needed we'll use a Pipeline to impute missing values, 
+encode categorical features and create interactions for specific variables using 
+Scikit-Learn's PolynomialFeatures.
 
 .. code:: python
     
@@ -166,6 +190,22 @@ Let's say you want to use :class:`SklearnTransformerWrapper()` in a more complex
     pipeline.fit(X_train)
     X_train_transformed = pipeline.transform(X_train)
     X_test_transformed = pipeline.transform(X_test)
+
+    print(X_train_transformed.head())
+            age        fare      embarked  pclass  sex  pclass sex
+    772  17.000000    7.8958         0     3.0     0.0      0.0
+    543  36.000000   10.5000         0     2.0     0.0      0.0
+    289  18.000000   79.6500         0     1.0     1.0      1.0
+    10   47.000000  227.5250         1     1.0     0.0      0.0
+    147  29.532738   42.4000         0     1.0     0.0      0.0
+
+    print(X_test_transformed.head())
+            age        fare      embarked  pclass  sex  pclass sex
+    1148  35.000000   7.1250         0     3.0     0.0      0.0
+    1049  20.000000  15.7417         1     3.0     0.0      0.0
+    982   29.532738   7.8958         0     3.0     0.0      0.0
+    808   29.532738   8.0500         0     3.0     0.0      0.0
+    1195  29.532738   7.7500         2     3.0     0.0      0.0
 
 More details
 ^^^^^^^^^^^^

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -285,7 +285,7 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
                 columns=self.transformer_.get_feature_names_out(self.variables_),
                 index=X.index,
             )
-            X = pd.concat([X.drop(columns = self.variables_), new_features_df], axis=1)
+            X = pd.concat([X.drop(columns=self.variables_), new_features_df], axis=1)
 
         # Feature selection: transformers that remove features
         elif self.transformer_.__class__.__name__ in _SELECTORS:
@@ -373,7 +373,11 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
                 added_features = self.transformer_.get_feature_names_out(
                     self.variables_
                 )
-                original_features = [feature for feature in self.feature_names_in_ if feature not in self.variables_]
+                original_features = [
+                    feature
+                    for feature in self.feature_names_in_
+                    if feature not in self.variables_
+                ]
                 feature_names = original_features + list(added_features)
             else:
                 feature_names = list(

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -285,7 +285,7 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
                 columns=self.transformer_.get_feature_names_out(self.variables_),
                 index=X.index,
             )
-            X = pd.concat([X, new_features_df], axis=1)
+            X = pd.concat([X.drop(columns = self.variables_), new_features_df], axis=1)
 
         # Feature selection: transformers that remove features
         elif self.transformer_.__class__.__name__ in _SELECTORS:
@@ -373,7 +373,8 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
                 added_features = self.transformer_.get_feature_names_out(
                     self.variables_
                 )
-                feature_names = list(self.feature_names_in_) + list(added_features)
+                original_features = [feature for feature in self.feature_names_in_ if feature not in self.variables_]
+                feature_names = original_features + list(added_features)
             else:
                 feature_names = list(
                     self.transformer_.get_feature_names_out(input_features)

--- a/tests/test_wrappers/test_sklearn_wrapper.py
+++ b/tests/test_wrappers/test_sklearn_wrapper.py
@@ -193,14 +193,54 @@ def test_wrap_polynomial_features():
 def test_wrap_polynomial_features_get_features_name_out():
     X = fetch_california_housing(as_frame=True).frame
 
-    tr = PolynomialFeatures()
-    tr_wrap = SklearnTransformerWrapper(transformer=PolynomialFeatures())
     varlist = ["MedInc", "HouseAge", "AveRooms", "AveBedrms"]
+    tr_wrap = SklearnTransformerWrapper(
+        transformer=PolynomialFeatures(), variables=varlist
+    )
 
-    tr.fit(X[varlist])
-    tr_wrap.fit(X[varlist])
+    tr_wrap.fit(X)
+    expected_features_all = [
+        "Population",
+        "AveOccup",
+        "Latitude",
+        "Longitude",
+        "MedHouseVal",
+        "1",
+        "MedInc",
+        "HouseAge",
+        "AveRooms",
+        "AveBedrms",
+        "MedInc^2",
+        "MedInc HouseAge",
+        "MedInc AveRooms",
+        "MedInc AveBedrms",
+        "HouseAge^2",
+        "HouseAge AveRooms",
+        "HouseAge AveBedrms",
+        "AveRooms^2",
+        "AveRooms AveBedrms",
+        "AveBedrms^2",
+    ]
+    expected_features_varlist = [
+        "1",
+        "MedInc",
+        "HouseAge",
+        "AveRooms",
+        "AveBedrms",
+        "MedInc^2",
+        "MedInc HouseAge",
+        "MedInc AveRooms",
+        "MedInc AveBedrms",
+        "HouseAge^2",
+        "HouseAge AveRooms",
+        "HouseAge AveBedrms",
+        "AveRooms^2",
+        "AveRooms AveBedrms",
+        "AveBedrms^2",
+    ]
 
-    assert (tr.get_feature_names_out() == tr_wrap.get_feature_names_out()).all()
+    assert tr_wrap.get_feature_names_out() == expected_features_all
+    assert tr_wrap.get_feature_names_out(varlist) == expected_features_varlist
 
 
 # SimpleImputer
@@ -419,12 +459,33 @@ def test_sklearn_ohe_with_crossvalidation():
 
 
 def test_wrap_one_hot_encoder_get_features_name_out(df_vartypes):
-    ohe = OneHotEncoder()
     ohe_wrap = SklearnTransformerWrapper(transformer=OneHotEncoder(sparse=False))
-    ohe.fit(df_vartypes)
     ohe_wrap.fit(df_vartypes)
 
-    assert (ohe.get_feature_names_out() == ohe_wrap.get_feature_names_out()).all()
+    expected_features_all = [
+        "Name_jack",
+        "Name_krish",
+        "Name_nick",
+        "Name_tom",
+        "City_Bristol",
+        "City_Liverpool",
+        "City_London",
+        "City_Manchester",
+        "Age_18",
+        "Age_19",
+        "Age_20",
+        "Age_21",
+        "Marks_0.6",
+        "Marks_0.7",
+        "Marks_0.8",
+        "Marks_0.9",
+        "dob_2020-02-24T00:00:00.000000000",
+        "dob_2020-02-24T00:01:00.000000000",
+        "dob_2020-02-24T00:02:00.000000000",
+        "dob_2020-02-24T00:03:00.000000000",
+    ]
+
+    assert ohe_wrap.get_feature_names_out() == expected_features_all
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wrappers/test_sklearn_wrapper.py
+++ b/tests/test_wrappers/test_sklearn_wrapper.py
@@ -190,6 +190,19 @@ def test_wrap_polynomial_features():
     assert Xw.shape[1] == len(tr.get_feature_names_out(X.columns))
 
 
+def test_wrap_polynomial_features_get_features_name_out():
+    X = fetch_california_housing(as_frame=True).frame
+
+    tr = PolynomialFeatures()
+    tr_wrap = SklearnTransformerWrapper(transformer=PolynomialFeatures())
+    varlist = ["MedInc", "HouseAge", "AveRooms", "AveBedrms"]
+
+    tr.fit(X[varlist])
+    tr_wrap.fit(X[varlist])
+
+    assert (tr.get_feature_names_out() == tr_wrap.get_feature_names_out()).all()
+
+
 # SimpleImputer
 def test_wrap_simple_imputer(df_na):
     variables_to_impute = ["Age", "Marks"]
@@ -264,7 +277,6 @@ def test_sklearn_imputer_allfeatures_with_constant(df_na):
 # One Hot Encoder
 def test_sklearn_ohe_object_one_feature(df_vartypes):
     variables_to_encode = ["Name"]
-    print("This:\n", df_vartypes)
 
     transformer = SklearnTransformerWrapper(
         transformer=OneHotEncoder(sparse=False, dtype=np.int64),
@@ -404,6 +416,15 @@ def test_sklearn_ohe_with_crossvalidation():
         pipeline, X, y, scoring="neg_mean_squared_error", cv=3
     )
     assert not any([np.isnan(i) for i in results])
+
+
+def test_wrap_one_hot_encoder_get_features_name_out(df_vartypes):
+    ohe = OneHotEncoder()
+    ohe_wrap = SklearnTransformerWrapper(transformer=OneHotEncoder(sparse=False))
+    ohe.fit(df_vartypes)
+    ohe_wrap.fit(df_vartypes)
+
+    assert (ohe.get_feature_names_out() == ohe_wrap.get_feature_names_out()).all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi @solegalli, 
This is my shot for fixing #489.
After checking the code in detail I think the issue affects not only `PolynomialFeatures` but also Sklearn `OneHotEncoder`.
When using `SklearnTransformerWrapper` + `OneHotEncoder` I get this:

![image](https://user-images.githubusercontent.com/48638337/182754479-8876a17f-93ab-43ec-8256-be2297ee74a3.png)

 Which is totally unexpected, since the idea is to replace Categorical Features for OneHotEncoded ones.

After the fix I'm proposing I get this for `OneHotEncoder`
![image](https://user-images.githubusercontent.com/48638337/182754799-4b073ea8-b484-4336-94f5-1fc917bc6939.png)

Which I think is the expected behavior. 

For `PolynomialFeatures` I get the following:
![image](https://user-images.githubusercontent.com/48638337/182754927-4d99ddbc-b8d0-4083-881b-e2281e368615.png)

Please note that an `OrdinalEncoder` was applied to Categorical Variables before applying `PolynomialFeatures`, otherwise it throws an error since they are not numerical features.

I think these cases could be added as test cases if you think it's OK. But before I would love to get your feedback.

Best,

Alfonso



