### PR TITLE
Ordinal encoder outputs -1 for unknown Categories

### DIFF
--- a/feature_engine/encoding/base_encoder.py
+++ b/feature_engine/encoding/base_encoder.py
@@ -231,7 +231,11 @@ class CategoricalMethodsMixin(BaseEstimator, TransformerMixin):
             else:
                 nan_columns_str = nan_columns[0]
 
-            if self.errors == "ignore":
+            if self.__class__.__name__ == "OrdinalEncoder" and self.errors == "ignore":
+                features = list(self.encoder_dict_.keys())
+                X[features] = X[features].fillna(-1).astype("int")
+
+            elif self.errors == "ignore":
                 warnings.warn(
                     "During the encoding, NaN values were introduced in the feature(s) "
                     f"{nan_columns_str}."
@@ -239,8 +243,7 @@ class CategoricalMethodsMixin(BaseEstimator, TransformerMixin):
             elif self.errors == "raise":
                 raise ValueError(
                     "During the encoding, NaN values were introduced in the feature(s) "
-                    f"{nan_columns_str}."
-                )
+                    f"{nan_columns_str}.")
 
         return X
 

--- a/tests/test_encoding/test_ordinal_encoder.py
+++ b/tests/test_encoding/test_ordinal_encoder.py
@@ -64,22 +64,23 @@ def test_error_if_ordinal_encoding_and_no_y_passed(df_enc):
 def test_error_if_input_df_contains_categories_not_present_in_training_df(
     df_enc, df_enc_rare
 ):
-    # test case 4: when dataset to be transformed contains categories not present
-    # in training dataset
     msg = "During the encoding, NaN values were introduced in the feature(s) var_A."
 
     # check for warning when rare_labels equals 'ignore'
-    with pytest.warns(UserWarning) as record:
-        encoder = OrdinalEncoder(errors="ignore")
-        encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
-        encoder.transform(df_enc_rare[["var_A", "var_B"]])
+    encoder = OrdinalEncoder(errors="ignore")
+    encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
+    tr_result = encoder.transform(df_enc_rare[["var_A", "var_B"]])
 
-    # check that only one warning was raised
-    assert len(record) == 1
-    # check that the message matches
-    assert record[0].message.args[0] == msg
+    answer = pd.DataFrame(
+        {
+            "var_A": 9 * [0] + 6 * [1] + 4 * [2] + [-1],
+            "var_B": 10 * [0] + 6 * [1] + 4 * [2],
+        }
+    )
 
-    # check for error when rare_labels equals 'raise'
+    # checking that Unknown categories output -1
+    pd.testing.assert_frame_equal(tr_result, answer)
+
     with pytest.raises(ValueError) as record:
         encoder = OrdinalEncoder(errors="raise")
         encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])


### PR DESCRIPTION
This is my shot for #428. 
I noticed `OrdinalEncoder` inherits the `transform` method from `CategoricalMethodsMixin`. So I added an additional condition to output -1 only for `OrdinalEncoder`.

Additionally I had to fix `test_error_if_input_df_contains_categories_not_present_in_training_df` in order for raise an error in case `errors='raise'` and check correctness if `errors='ignore'`.