### PR TITLE
Add code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+# configuration for coverage.py
+
+[run]
+branch = True
+source = feature_engine
+omit =
+    */tags.py
+    */_docstrings/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,12 @@ source = feature_engine
 omit =
     */tags.py
     */_docstrings/*
+    */_datetime_constants.py
+    */_docstings.py
+    */_selection_constants.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def _more_tags
+show_missing = True

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -18,4 +18,7 @@
             <a href='https://github.com/nicogalli'><img src='https://avatars.githubusercontent.com/nicogalli?v=4' class='avatar'width="120" height="120"/></a> <br />
             <p>Nicolas Galli</p>
         </div>
+        <div class="author">
+            <a href='https://github.com/morgan-sell'><img src='https://avatars.githubusercontent.com/morgan-sell?v=4' class='avatar' width="120" height="120" /></a> <br />
+            <p>Morgan Sell</p>
     </div>

--- a/feature_engine/transformation/boxcox.py
+++ b/feature_engine/transformation/boxcox.py
@@ -139,6 +139,10 @@ class BoxCoxTransformer(BaseNumericalTransformer):
         # check input dataframe and if class was fitted
         X = super().transform(X)
 
+        # check contains zero or negative values
+        if (X[self.variables_] <= 0).any().any():
+            raise ValueError("Data must be positive.")
+
         # transform
         for feature in self.variables_:
             X[feature] = stats.boxcox(X[feature], lmbda=self.lambda_dict_[feature])

--- a/tests/test_transformation/test_boxcox_transformer.py
+++ b/tests/test_transformation/test_boxcox_transformer.py
@@ -36,16 +36,16 @@ def test_automatically_finds_variables(df_vartypes):
 
 def test_fit_raises_error_if_df_contains_na(df_na):
     # test case 2: when dataset contains na, fit method
+    transformer = BoxCoxTransformer()
     with pytest.raises(ValueError):
-        transformer = BoxCoxTransformer()
         transformer.fit(df_na)
 
 
 def test_transform_raises_error_if_df_contains_na(df_vartypes, df_na):
     # test case 3: when dataset contains na, transform method
+    transformer = BoxCoxTransformer()
+    transformer.fit(df_vartypes)
     with pytest.raises(ValueError):
-        transformer = BoxCoxTransformer()
-        transformer.fit(df_vartypes)
         transformer.transform(df_na[["Name", "City", "Age", "Marks", "dob"]])
 
 
@@ -55,18 +55,18 @@ def test_error_if_df_contains_negative_values(df_vartypes):
     df_neg.loc[1, "Age"] = -1
 
     # test case 4: when variable contains negative value, fit
+    transformer = BoxCoxTransformer()
     with pytest.raises(ValueError):
-        transformer = BoxCoxTransformer()
         transformer.fit(df_neg)
 
     # test case 5: when variable contains negative value, transform
+    transformer = BoxCoxTransformer()
+    transformer.fit(df_vartypes)
     with pytest.raises(ValueError):
-        transformer = BoxCoxTransformer()
-        transformer.fit(df_vartypes)
         transformer.transform(df_neg)
 
 
 def test_non_fitted_error(df_vartypes):
+    transformer = BoxCoxTransformer()
     with pytest.raises(NotFittedError):
-        transformer = BoxCoxTransformer()
         transformer.transform(df_vartypes)


### PR DESCRIPTION
Code coverage will allow us to measure how much of the feature-engine source code is tested.

Closes #323.

Notes from #323:

At the moment, we have no visibility of test coverage. I would like to include this in the package.

Here some useful links I gathered:

https://gist.github.com/dnozay/5b9b818ff0dc857d1358

https://pytest-cov.readthedocs.io/en/latest/tox.html

https://coverage.readthedocs.io/en/6.1.1/config.html

Also check imbalanced-learn package, they have some code to run coverage.