### PR TITLE
refactor get feature names out in creation module

### DIFF
--- a/feature_engine/creation/base_creation.py
+++ b/feature_engine/creation/base_creation.py
@@ -123,8 +123,8 @@ class GetFeatureNamesOutMixin:
 
         check_is_fitted(self)
 
-        msg = f"""input features must be None or a list with one or more of the 
-        variables that were used by this transformer. Got {input_features} instead."""
+        msg = f"""input features must be None or a list with one or more of the
+         variables that were used by this transformer. Got {input_features} instead."""
 
         if input_features is None:
             # Return original variables

--- a/feature_engine/creation/base_creation.py
+++ b/feature_engine/creation/base_creation.py
@@ -123,8 +123,8 @@ class GetFeatureNamesOutMixin:
 
         check_is_fitted(self)
 
-        msg = f"""input features must be None or a list with one or more of the variables
-        that were used by this transformer. Got {input_features} instead."""
+        msg = f"""input features must be None or a list with one or more of the 
+        variables that were used by this transformer. Got {input_features} instead."""
 
         if input_features is None:
             # Return original variables

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -17,7 +17,7 @@ from feature_engine._docstrings.methods import (
     _transform_creation_docstring,
 )
 from feature_engine._docstrings.substitute import Substitution
-from feature_engine.creation.base_creation import BaseCreation
+from feature_engine.creation.base_creation import BaseCreation, GetFeatureNamesOutMixin
 
 
 @Substitution(
@@ -29,7 +29,7 @@ from feature_engine.creation.base_creation import BaseCreation
     transform=_transform_creation_docstring,
     fit_transform=_fit_transform_docstring,
 )
-class MathFeatures(BaseCreation):
+class MathFeatures(BaseCreation, GetFeatureNamesOutMixin):
     """
     MathFeatures(() applies functions across multiple features returning one or more
     additional features as a result. It uses `pandas.agg()` to create the features,
@@ -242,15 +242,10 @@ class MathFeatures(BaseCreation):
             else:
                 feature_names = [f"{self.func}_{'_'.join(varlist)}"]
 
-        # organise return of method
-        if input_features is None or input_features is False:
-            if self.drop_original is True:
-                # Remove names of variables to drop.
-                original = [
-                    f for f in self.feature_names_in_ if f not in self.variables
-                ]
-                feature_names = original + feature_names
-            else:
-                feature_names = self.feature_names_in_ + feature_names
+        # Return names of all variables if input_features is None, or just those
+        # derived from input features
+        feature_names = super()._return_feature_names(
+            input_features, feature_names, self.variables
+        )
 
         return feature_names

--- a/feature_engine/creation/relative_features.py
+++ b/feature_engine/creation/relative_features.py
@@ -21,7 +21,7 @@ from feature_engine._docstrings.substitute import Substitution
 from feature_engine._variable_handling.variable_type_selection import (
     _find_or_check_numerical_variables,
 )
-from feature_engine.creation.base_creation import BaseCreation
+from feature_engine.creation.base_creation import BaseCreation, GetFeatureNamesOutMixin
 
 _PERMITTED_FUNCTIONS = [
     "add",
@@ -45,7 +45,7 @@ _PERMITTED_FUNCTIONS = [
     transform=_transform_creation_docstring,
     fit_transform=_fit_transform_docstring,
 )
-class RelativeFeatures(BaseCreation):
+class RelativeFeatures(BaseCreation, GetFeatureNamesOutMixin):
     """
     RelativeFeatures() applies basic mathematical operations between a group
     of variables and one or more reference features. It adds the resulting features
@@ -313,16 +313,10 @@ class RelativeFeatures(BaseCreation):
             for var in self.variables
         ]
 
-        if input_features is None or input_features is False:
-            if self.drop_original is True:
-                # Remove names of variables to drop.
-                original = [
-                    f
-                    for f in self.feature_names_in_
-                    if f not in self.variables + self.reference
-                ]
-                feature_names = original + feature_names
-            else:
-                feature_names = self.feature_names_in_ + feature_names
+        # Return names of all variables if input_features is None, or just those
+        # derived from input features
+        feature_names = super()._return_feature_names(
+            input_features, feature_names, self.variables + self.reference
+        )
 
         return feature_names


### PR DESCRIPTION
- [ ] check that the error message is shown correctly
 
Should we change the logic of the MathFeatures and RelativeFeatures?

At the moment, they take only None or Bool. Should they take list? and what should they return in that case?

We should probably follow the logic of the PolynomialFeatures if that one makes sense.