### PR TITLE
Adding examples for Encoding Module 

### DIFF
--- a/docs/_static/js/copybutton.js
+++ b/docs/_static/js/copybutton.js
@@ -1,0 +1,63 @@
+$(document).ready(function() {
+    /* Add a [>>>] button on the top-right corner of code samples to hide
+     * the >>> and ... prompts and the output and thus make the code
+     * copyable. */
+    var div = $('.highlight-python .highlight,' +
+                '.highlight-python3 .highlight,' +
+                '.highlight-pycon .highlight,' +
+		'.highlight-default .highlight')
+    var pre = div.find('pre');
+
+    // get the styles from the current theme
+    pre.parent().parent().css('position', 'relative');
+    var hide_text = 'Hide the prompts and output';
+    var show_text = 'Show the prompts and output';
+    var border_width = pre.css('border-top-width');
+    var border_style = pre.css('border-top-style');
+    var border_color = pre.css('border-top-color');
+    var button_styles = {
+        'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
+        'border-color': border_color, 'border-style': border_style,
+        'border-width': border_width, 'color': border_color, 'text-size': '75%',
+        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
+        'border-radius': '0 3px 0 0'
+    }
+
+    // create and add the button to all the code blocks that contain >>>
+    div.each(function(index) {
+        var jthis = $(this);
+        if (jthis.find('.gp').length > 0) {
+            var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
+            button.css(button_styles)
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+            jthis.prepend(button);
+        }
+        // tracebacks (.gt) contain bare text elements that need to be
+        // wrapped in a span to work with .nextUntil() (see later)
+        jthis.find('pre:has(.gt)').contents().filter(function() {
+            return ((this.nodeType == 3) && (this.data.trim().length > 0));
+        }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('title', show_text);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+        }
+    });
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,3 +299,4 @@ linkcode_resolve = make_linkcode_resolve(
 def setup(app):
     kwargs = {"defer data-domain":"feature-engine.readthedocs.io"}
     app.add_js_file("https://plausible.io/js/plausible.js", **kwargs)
+    app.add_js_file("js/copybutton.js")

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -119,6 +119,16 @@ class CountFrequencyEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
     --------
     feature_engine.encoding.RareLabelEncoder
     category_encoders.count.CountEncoder
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import CountFrequencyEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4], b = ["c", "a", "b", "c"]))
+    >>> cf = CountFrequencyEncoder(encoding_method='count')
+    >>> cf.fit(X)
+    >>> cf.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -125,10 +125,24 @@ class CountFrequencyEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import CountFrequencyEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4], b = ["c", "a", "b", "c"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4], x2 = ["c", "a", "b", "c"]))
     >>> cf = CountFrequencyEncoder(encoding_method='count')
     >>> cf.fit(X)
     >>> cf.transform(X)
+       x1  x2
+    0   1   2
+    1   2   1
+    2   3   1
+    3   4   2
+
+    >>> cf = CountFrequencyEncoder(encoding_method='frequency')
+    >>> cf.fit(X)
+    >>> cf.transform(X)
+       x1    x2
+    0   1  0.50
+    1   2  0.25
+    2   3  0.25
+    3   4  0.50
     """
 
     def __init__(

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -156,6 +156,17 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
     .. [1] Niculescu-Mizil, et al. "Winning the KDD Cup Orange Challenge with Ensemble
         Selection". JMLR: Workshop and Conference Proceedings 7: 23-34. KDD 2009
         http://proceedings.mlr.press/v7/niculescu09/niculescu09.pdf
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import DecisionTreeEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5], b = ["b", "b", "b", "a", "a"]))
+    >>> y = pd.Series([2.2,4, 1.5, 3.2, 1.1])
+    >>> ohe = DecisionTreeEncoder(cv=2)
+    >>> ohe.fit(X, y)
+    >>> ohe.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -162,11 +162,30 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import DecisionTreeEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5], b = ["b", "b", "b", "a", "a"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4,5], x2 = ["b", "b", "b", "a", "a"]))
     >>> y = pd.Series([2.2,4, 1.5, 3.2, 1.1])
-    >>> ohe = DecisionTreeEncoder(cv=2)
-    >>> ohe.fit(X, y)
-    >>> ohe.transform(X)
+    >>> dte = DecisionTreeEncoder(cv=2)
+    >>> dte.fit(X, y)
+    >>> dte.transform(X)
+       x1        x2
+    0   1  2.566667
+    1   2  2.566667
+    2   3  2.566667
+    3   4  2.150000
+    4   5  2.150000
+
+    You can also use it for classification by using `regression=False`.
+
+    >>> y = pd.Series([0,1,1,1,0])
+    >>> dte = DecisionTreeEncoder(regression=False, cv=2)
+    >>> dte.fit(X, y)
+    >>> dte.transform(X)
+       x1        x2
+    0   1  0.666667
+    1   2  0.666667
+    2   3  0.666667
+    3   4  0.500000
+    4   5  0.500000
     """
 
     def __init__(

--- a/feature_engine/encoding/mean_encoding.py
+++ b/feature_engine/encoding/mean_encoding.py
@@ -146,6 +146,17 @@ class MeanEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
     .. [1] Micci-Barreca D. "A Preprocessing Scheme for High-Cardinality Categorical
        Attributes in Classification and Prediction Problems". ACM SIGKDD Explorations
        Newsletter, 2001. https://dl.acm.org/citation.cfm?id=507538
+
+        Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import MeanEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5], b = ["c", "c", "c", "b", "a"]))
+    >>> y = pd.Series([0,1,1,1,0])
+    >>> me = MeanEncoder()
+    >>> me.fit(X,y)
+    >>> me.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/mean_encoding.py
+++ b/feature_engine/encoding/mean_encoding.py
@@ -147,16 +147,22 @@ class MeanEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
        Attributes in Classification and Prediction Problems". ACM SIGKDD Explorations
        Newsletter, 2001. https://dl.acm.org/citation.cfm?id=507538
 
-        Examples
+    Examples
     --------
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import MeanEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5], b = ["c", "c", "c", "b", "a"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4,5], x2 = ["c", "c", "c", "b", "a"]))
     >>> y = pd.Series([0,1,1,1,0])
     >>> me = MeanEncoder()
     >>> me.fit(X,y)
     >>> me.transform(X)
+       x1        x2
+    0   1  0.666667
+    1   2  0.666667
+    2   3  0.666667
+    3   4  1.000000
+    4   5  0.000000
     """
 
     def __init__(

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -146,10 +146,15 @@ class OneHotEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import OneHotEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4], b = ["a", "a", "b", "c"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4], x2 = ["a", "a", "b", "c"]))
     >>> ohe = OneHotEncoder()
     >>> ohe.fit(X)
     >>> ohe.transform(X)
+       x1  x2_a  x2_b  x2_c
+    0   1     1     0     0
+    1   2     1     0     0
+    2   3     0     1     0
+    3   4     0     0     1
     """
 
     def __init__(

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -140,6 +140,16 @@ class OneHotEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
     .. [1] Niculescu-Mizil, et al. "Winning the KDD Cup Orange Challenge with Ensemble
         Selection". JMLR: Workshop and Conference Proceedings 7: 23-34. KDD 2009
         http://proceedings.mlr.press/v7/niculescu09/niculescu09.pdf
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import OneHotEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4], b = ["a", "a", "b", "c"]))
+    >>> ohe = OneHotEncoder()
+    >>> ohe.fit(X)
+    >>> ohe.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/ordinal.py
+++ b/feature_engine/encoding/ordinal.py
@@ -123,6 +123,22 @@ class OrdinalEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     .. [1] Galli S. "Machine Learning in Financial Risk Assessment".
         https://www.youtube.com/watch?v=KHGGlozsRtA
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import OrdinalEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4],b = ["c", "a", "b", "c"]))
+    >>> y = pd.Series([0,1,1,0])
+    >>> od = OrdinalEncoder(encoding_method='arbitrary')
+    >>> od.fit(X)
+    >>> od.transform(X)
+
+    >>> y = pd.Series([1,0,1,1])
+    >>> od = OrdinalEncoder(encoding_method='ordered')
+    >>> od.fit(X, y)
+    >>> od.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/ordinal.py
+++ b/feature_engine/encoding/ordinal.py
@@ -129,16 +129,28 @@ class OrdinalEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import OrdinalEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4],b = ["c", "a", "b", "c"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4], x2 = ["c", "a", "b", "c"]))
     >>> y = pd.Series([0,1,1,0])
     >>> od = OrdinalEncoder(encoding_method='arbitrary')
     >>> od.fit(X)
     >>> od.transform(X)
+       x1  x2
+    0   1   0
+    1   2   1
+    2   3   2
+    3   4   0
+
+    You can also consider the order of the target variable:
 
     >>> y = pd.Series([1,0,1,1])
     >>> od = OrdinalEncoder(encoding_method='ordered')
     >>> od.fit(X, y)
     >>> od.transform(X)
+       x1  x2
+    0   1   2
+    1   2   0
+    2   3   1
+    3   4   2
     """
 
     def __init__(

--- a/feature_engine/encoding/rare_label.py
+++ b/feature_engine/encoding/rare_label.py
@@ -115,10 +115,17 @@ class RareLabelEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import RareLabelEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5,6], b = ["b", "b", "b", "b", "b", "a"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4,5,6], x2 = ["b", "b", "b", "b", "b", "a"]))
     >>> rle = RareLabelEncoder(n_categories = 1, tol=0.2)
     >>> rle.fit(X)
     >>> rle.transform(X)
+       x1    x2
+    0   1     b
+    1   2     b
+    2   3     b
+    3   4     b
+    4   5     b
+    5   6  Rare
     """
 
     def __init__(

--- a/feature_engine/encoding/rare_label.py
+++ b/feature_engine/encoding/rare_label.py
@@ -109,6 +109,16 @@ class RareLabelEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     transform:
         Group rare categories
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import RareLabelEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5,6], b = ["b", "b", "b", "b", "b", "a"]))
+    >>> rle = RareLabelEncoder(n_categories = 1, tol=0.2)
+    >>> rle.fit(X)
+    >>> rle.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/similarity_encoder.py
+++ b/feature_engine/encoding/similarity_encoder.py
@@ -162,10 +162,15 @@ class StringSimilarityEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import StringSimilarityEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5,6], b = ["dog", "dog", "dig", "dagger", "dagger", "hi"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4], x2 = ["dog", "dig", "dagger", "hi"]))
     >>> sse = StringSimilarityEncoder()
     >>> sse.fit(X)
     >>> sse.transform(X)
+       x1    x2_dog    x2_dig  x2_dagger  x2_hi
+    0   1  1.000000  0.666667   0.444444    0.0
+    1   2  0.666667  1.000000   0.444444    0.4
+    2   3  0.444444  0.444444   1.000000    0.0
+    3   4  0.000000  0.400000   0.000000    1.0
     """
 
     def __init__(

--- a/feature_engine/encoding/similarity_encoder.py
+++ b/feature_engine/encoding/similarity_encoder.py
@@ -156,6 +156,16 @@ class StringSimilarityEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
        categorical variables". Machine Learning, Springer Verlag, 2018.
     .. [2] Cerda P, Varoquaux G. "Encoding high-cardinality string categorical
        variables". IEEE Transactions on Knowledge & Data Engineering, 2020.
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import StringSimilarityEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5,6], b = ["dog", "dog", "dig", "dagger", "dagger", "hi"]))
+    >>> sse = StringSimilarityEncoder()
+    >>> sse.fit(X)
+    >>> sse.transform(X)
     """
 
     def __init__(

--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -162,11 +162,17 @@ class WoEEncoder(CategoricalInitMixin, CategoricalMethodsMixin, WoE):
 
     >>> import pandas as pd
     >>> from feature_engine.encoding import WoEEncoder
-    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5], b = ["b", "b", "b", "a", "a"]))
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3,4,5], x2 = ["b", "b", "b", "a", "a"]))
     >>> y = pd.Series([0,1,1,1,0])
     >>> woe = WoEEncoder()
     >>> woe.fit(X, y)
     >>> woe.transform(X)
+       x1        x2
+    0   1  0.287682
+    1   2  0.287682
+    2   3  0.287682
+    3   4 -0.405465
+    4   5 -0.405465
     """
 
     def __init__(

--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -156,6 +156,17 @@ class WoEEncoder(CategoricalInitMixin, CategoricalMethodsMixin, WoE):
     feature_engine.encoding.RareLabelEncoder
     feature_engine.discretisation
     category_encoders.woe.WOEEncoder
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.encoding import WoEEncoder
+    >>> X = pd.DataFrame(dict(a = [1,2,3,4,5], b = ["b", "b", "b", "a", "a"]))
+    >>> y = pd.Series([0,1,1,1,0])
+    >>> woe = WoEEncoder()
+    >>> woe.fit(X, y)
+    >>> woe.transform(X)
     """
 
     def __init__(


### PR DESCRIPTION
Hi @solegalli 

I just added examples for the encoding module. 
* I would like your feedback on this especially because I'm not sure how to test this examples are ok. Is there any way to render a dev documentation to see it?
* Second, scikit-learn shows some kind of glimpse of the answer, but they use `np.arrays` so it's a bit more concise than showing a glimpse of a dataframe, what do you think about that?

Please let me know if we are OK with this before start working on other modules. 

Finally, do you think it could be a good a idea to have some notebooks for every module with this examples?

Thanks, 

Alfonso