### PR TITLE
Add fill_value param to forecasting classes to handle NA as per pandas

### DIFF
--- a/feature_engine/_docstrings/init_parameters.py
+++ b/feature_engine/_docstrings/init_parameters.py
@@ -36,3 +36,9 @@ _unseen_docstring = """unseen: string, default='ignore'
         error. If 'ignore', then unseen categories will be set as NaN and a warning will
         be raised instead.
     """.rstrip()
+
+
+# used in forecasting
+_fill_values_docstring = """fill_values: Union[float, int, str], default=None
+    The scalar value to use for newly introduced missing values.
+"""

--- a/feature_engine/_docstrings/init_parameters.py
+++ b/feature_engine/_docstrings/init_parameters.py
@@ -39,5 +39,5 @@ _unseen_docstring = """unseen: string, default='ignore'
 
 # used in forecasting
 _fill_value_docstring = """fill_values: Hashable, default=lib.no_default
-    The scalar value to use for newly introduced missing values.
-"""
+        The scalar value to use for newly introduced missing values.
+    """.rstrip()

--- a/feature_engine/_docstrings/init_parameters.py
+++ b/feature_engine/_docstrings/init_parameters.py
@@ -37,8 +37,7 @@ _unseen_docstring = """unseen: string, default='ignore'
         be raised instead.
     """.rstrip()
 
-
 # used in forecasting
-_fill_values_docstring = """fill_values: Union[float, int, str], default=None
+_fill_value_docstring = """fill_values: Hashable, default=lib.no_default
     The scalar value to use for newly introduced missing values.
 """

--- a/feature_engine/timeseries/forecasting/base_forecast_transformers.py
+++ b/feature_engine/timeseries/forecasting/base_forecast_transformers.py
@@ -14,6 +14,7 @@ from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
     _missing_values_docstring,
     _fill_value_docstring,
+
 )
 from feature_engine._docstrings.methods import _fit_not_learn_docstring
 from feature_engine._docstrings.substitute import Substitution

--- a/feature_engine/timeseries/forecasting/base_forecast_transformers.py
+++ b/feature_engine/timeseries/forecasting/base_forecast_transformers.py
@@ -50,6 +50,7 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
 
     {drop_original}
 
+
     Attributes
     ----------
     {feature_names_in_}
@@ -63,6 +64,7 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
         variables: Union[None, int, str, List[Union[str, int]]] = None,
         missing_values: str = "raise",
         drop_original: bool = False,
+        fill_value: Union[float, int, str] = None,
     ) -> None:
 
         if missing_values not in ["raise", "ignore"]:
@@ -77,9 +79,16 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
                 f"Got {drop_original} instead."
             )
 
+        if not isinstance(fill_value, (float, int, str)):
+            raise ValueError(
+                "fill_value takes only float, integer, or string. "
+                f"Got {fill_value} instead."
+            )
+
         self.variables = _check_init_parameter_variables(variables)
         self.missing_values = missing_values
         self.drop_original = drop_original
+        self.fill_value = fill_value
 
     def _check_index(self, X: pd.DataFrame):
         """

--- a/feature_engine/timeseries/forecasting/base_forecast_transformers.py
+++ b/feature_engine/timeseries/forecasting/base_forecast_transformers.py
@@ -68,10 +68,16 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
     def __init__(
         self,
         variables: Union[None, int, str, List[Union[str, int]]] = None,
-        fill_value: Hashable = lib.no_default,
+        fill_value: Union[None, int, float, str] = None,
         missing_values: str = "raise",
         drop_original: bool = False,
     ) -> None:
+
+        if fill_value is not None and not isinstance(fill_value, (int, float, str)):
+            raise ValueError(
+                "fill_value must be None type, integer, float or string. "
+                f"Got {fill_value} instead."
+            )
 
         if missing_values not in ["raise", "ignore"]:
             raise ValueError(

--- a/feature_engine/timeseries/forecasting/base_forecast_transformers.py
+++ b/feature_engine/timeseries/forecasting/base_forecast_transformers.py
@@ -1,6 +1,7 @@
-from typing import List, Optional, Union
+from typing import Hashable, List, Optional, Union
 
 import pandas as pd
+from pandas._libs import lib
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -66,16 +67,10 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
     def __init__(
         self,
         variables: Union[None, int, str, List[Union[str, int]]] = None,
-        fill_value: Union[float, int, str] = None,
+        fill_value: Hashable = lib.no_default,
         missing_values: str = "raise",
         drop_original: bool = False,
     ) -> None:
-
-        if not isinstance(fill_value, (float, int, str)):
-            raise ValueError(
-                "fill_value takes only float, integer, or string. "
-                f"Got {fill_value} instead."
-            )
 
         if missing_values not in ["raise", "ignore"]:
             raise ValueError(

--- a/feature_engine/timeseries/forecasting/base_forecast_transformers.py
+++ b/feature_engine/timeseries/forecasting/base_forecast_transformers.py
@@ -12,6 +12,7 @@ from feature_engine._docstrings.fit_attributes import (
 from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
     _missing_values_docstring,
+    _fill_values_docstring,
 )
 from feature_engine._docstrings.methods import _fit_not_learn_docstring
 from feature_engine._docstrings.substitute import Substitution
@@ -31,6 +32,7 @@ from feature_engine.tags import _return_tags
 
 
 @Substitution(
+    fill_value=_fill_values_docstring,
     missing_values=_missing_values_docstring,
     drop_original=_drop_original_docstring,
     feature_names_in_=_feature_names_in_docstring,
@@ -45,6 +47,8 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
     ----------
     variables: str, int, or list of strings or integers, default=None.
         The variables to use to create the new features.
+
+    {fill_value}
 
     {missing_values}
 
@@ -62,10 +66,16 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
     def __init__(
         self,
         variables: Union[None, int, str, List[Union[str, int]]] = None,
+        fill_value: Union[float, int, str] = None,
         missing_values: str = "raise",
         drop_original: bool = False,
-        fill_value: Union[float, int, str] = None,
     ) -> None:
+
+        if not isinstance(fill_value, (float, int, str)):
+            raise ValueError(
+                "fill_value takes only float, integer, or string. "
+                f"Got {fill_value} instead."
+            )
 
         if missing_values not in ["raise", "ignore"]:
             raise ValueError(
@@ -79,16 +89,11 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
                 f"Got {drop_original} instead."
             )
 
-        if not isinstance(fill_value, (float, int, str)):
-            raise ValueError(
-                "fill_value takes only float, integer, or string. "
-                f"Got {fill_value} instead."
-            )
-
         self.variables = _check_init_parameter_variables(variables)
+        self.fill_value = fill_value
         self.missing_values = missing_values
         self.drop_original = drop_original
-        self.fill_value = fill_value
+
 
     def _check_index(self, X: pd.DataFrame):
         """

--- a/feature_engine/timeseries/forecasting/base_forecast_transformers.py
+++ b/feature_engine/timeseries/forecasting/base_forecast_transformers.py
@@ -13,7 +13,7 @@ from feature_engine._docstrings.fit_attributes import (
 from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
     _missing_values_docstring,
-    _fill_values_docstring,
+    _fill_value_docstring,
 )
 from feature_engine._docstrings.methods import _fit_not_learn_docstring
 from feature_engine._docstrings.substitute import Substitution
@@ -33,7 +33,7 @@ from feature_engine.tags import _return_tags
 
 
 @Substitution(
-    fill_value=_fill_values_docstring,
+    fill_value=_fill_value_docstring,
     missing_values=_missing_values_docstring,
     drop_original=_drop_original_docstring,
     feature_names_in_=_feature_names_in_docstring,
@@ -88,7 +88,6 @@ class BaseForecastTransformer(BaseEstimator, TransformerMixin, GetFeatureNamesOu
         self.fill_value = fill_value
         self.missing_values = missing_values
         self.drop_original = drop_original
-
 
     def _check_index(self, X: pd.DataFrame):
         """

--- a/feature_engine/timeseries/forecasting/expanding_window_features.py
+++ b/feature_engine/timeseries/forecasting/expanding_window_features.py
@@ -183,11 +183,7 @@ class ExpandingWindowFeatures(BaseForecastTransformer):
             X[self.variables_]
                 .expanding(min_periods=self.min_periods)
                 .agg(self.functions)
-                .shift(
-                    periods=self.periods,
-                    freq=self.freq,
-                    fill_value=self.fill_value,
-                )
+                .shift(periods=self.periods, freq=self.freq, fill_value=self.fill_value)
         )
 
         tmp.columns = self._get_new_features_name()

--- a/feature_engine/timeseries/forecasting/expanding_window_features.py
+++ b/feature_engine/timeseries/forecasting/expanding_window_features.py
@@ -2,10 +2,10 @@
 # License: BSD 3 clause
 
 from __future__ import annotations
-from typing import List
+from typing import Hashable, List
 
 import pandas as pd
-
+from pandas._libs import lib
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -14,7 +14,7 @@ from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
     _missing_values_docstring,
     _variables_numerical_docstring,
-    _fill_values_docstring,
+    _fill_value_docstring,
 )
 from feature_engine._docstrings.methods import (
     _fit_not_learn_docstring,
@@ -30,7 +30,7 @@ from feature_engine.timeseries.forecasting.base_forecast_transformers import (
     variables=_variables_numerical_docstring,
     missing_values=_missing_values_docstring,
     drop_original=_drop_original_docstring,
-    fill_value=_fill_values_docstring,
+    fill_value=_fill_value_docstring,
     feature_names_in_=_feature_names_in_docstring,
     n_features_in_=_n_features_in_docstring,
     fit=_fit_not_learn_docstring,
@@ -131,7 +131,7 @@ class ExpandingWindowFeatures(BaseForecastTransformer):
         periods: int = 1,
         freq: str = None,
         sort_index: bool = True,
-        fill_value: Union[float, int, str] = None,
+        fill_value: Hashable = lib.no_default,
         missing_values: str = "raise",
         drop_original: bool = False,
 
@@ -179,27 +179,16 @@ class ExpandingWindowFeatures(BaseForecastTransformer):
         # Common dataframe checks and setting up.
         X = super().transform(X)
 
-        # use pandas shift default autodetect
-        if self.fill_value is None:
-            tmp = (
-                X[self.variables_]
+        tmp = (
+            X[self.variables_]
                 .expanding(min_periods=self.min_periods)
                 .agg(self.functions)
-                .shift(periods=self.periods, freq=self.freq)
-            )
-
-        # use user provided value
-        else:
-            tmp = (
-                X[self.variables_]
-                    .expanding(min_periods=self.min_periods)
-                    .agg(self.functions)
-                    .shift(
-                        periods=self.periods,
-                        freq=self.freq,
-                        fill_value=self.fill_value
-                    )
-            )
+                .shift(
+                    periods=self.periods,
+                    freq=self.freq,
+                    fill_value=self.fill_value,
+                )
+        )
 
         tmp.columns = self._get_new_features_name()
 

--- a/feature_engine/timeseries/forecasting/expanding_window_features.py
+++ b/feature_engine/timeseries/forecasting/expanding_window_features.py
@@ -92,6 +92,7 @@ class ExpandingWindowFeatures(BaseForecastTransformer):
 
     {drop_original}
 
+
     Attributes
     ----------
     variables_:

--- a/feature_engine/timeseries/forecasting/lag_features.py
+++ b/feature_engine/timeseries/forecasting/lag_features.py
@@ -1,9 +1,10 @@
 # Authors: Morgan Sell <morganpsell@gmail.com>
 # License: BSD 3 clause
 
-from typing import List, Union
+from typing import Hashable, List, Union
 
 import pandas as pd
+from pandas._libs import lib
 
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
@@ -11,6 +12,7 @@ from feature_engine._docstrings.fit_attributes import (
 )
 from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
+    _fill_value_docstring,
     _missing_values_docstring,
     _variables_numerical_docstring,
 )
@@ -70,6 +72,8 @@ class LagFeatures(BaseForecastTransformer):
     sort_index: bool, default=True
         Whether to order the index of the dataframe before creating the lag features.
 
+    {fill_value}
+
     {missing_values}
 
     {drop_original}
@@ -103,6 +107,7 @@ class LagFeatures(BaseForecastTransformer):
         periods: Union[int, List[int]] = 1,
         freq: Union[str, List[str]] = None,
         sort_index: bool = True,
+        fill_value: Hashable = lib.no_default,
         missing_values: str = "raise",
         drop_original: bool = False,
     ) -> None:
@@ -129,7 +134,9 @@ class LagFeatures(BaseForecastTransformer):
                 "sort_index takes values True and False." f"Got {sort_index} instead."
             )
 
-        super().__init__(variables, missing_values, drop_original)
+        super().__init__(
+            variables, missing_values, drop_original, fill_value
+        )
 
         self.periods = periods
         self.freq = freq
@@ -161,6 +168,7 @@ class LagFeatures(BaseForecastTransformer):
                     tmp = X[self.variables_].shift(
                         freq=fr,
                         axis=0,
+                        fill_value=self.fill_value,
                     )
                     df_ls.append(tmp)
                 tmp = pd.concat(df_ls, axis=1)
@@ -169,6 +177,7 @@ class LagFeatures(BaseForecastTransformer):
                 tmp = X[self.variables_].shift(
                     freq=self.freq,
                     axis=0,
+                    fill_value=self.fill_value,
                 )
 
         else:
@@ -178,6 +187,7 @@ class LagFeatures(BaseForecastTransformer):
                     tmp = X[self.variables_].shift(
                         periods=pr,
                         axis=0,
+                        fill_value=self.fill_value,
                     )
                     df_ls.append(tmp)
                 tmp = pd.concat(df_ls, axis=1)
@@ -186,6 +196,7 @@ class LagFeatures(BaseForecastTransformer):
                 tmp = X[self.variables_].shift(
                     periods=self.periods,
                     axis=0,
+                    fill_value=self.fill_value,
                 )
 
         tmp.columns = self._get_new_features_name()

--- a/feature_engine/timeseries/forecasting/lag_features.py
+++ b/feature_engine/timeseries/forecasting/lag_features.py
@@ -12,7 +12,6 @@ from feature_engine._docstrings.fit_attributes import (
 )
 from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
-    _fill_value_docstring,
     _missing_values_docstring,
     _variables_numerical_docstring,
 )
@@ -72,7 +71,6 @@ class LagFeatures(BaseForecastTransformer):
     sort_index: bool, default=True
         Whether to order the index of the dataframe before creating the lag features.
 
-    {fill_value}
 
     {missing_values}
 

--- a/feature_engine/timeseries/forecasting/lag_features.py
+++ b/feature_engine/timeseries/forecasting/lag_features.py
@@ -1,10 +1,9 @@
 # Authors: Morgan Sell <morganpsell@gmail.com>
 # License: BSD 3 clause
 
-from typing import Hashable, List, Union
+from typing import List, Union
 
 import pandas as pd
-from pandas._libs import lib
 
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
@@ -105,7 +104,7 @@ class LagFeatures(BaseForecastTransformer):
         periods: Union[int, List[int]] = 1,
         freq: Union[str, List[str]] = None,
         sort_index: bool = True,
-        fill_value: Hashable = lib.no_default,
+        fill_value: Union[None, int, float, str] = None,
         missing_values: str = "raise",
         drop_original: bool = False,
     ) -> None:
@@ -196,7 +195,7 @@ class LagFeatures(BaseForecastTransformer):
         X = X.merge(tmp, left_index=True, right_index=True, how="left")
 
         # if user passes a fill_value, fill NaN
-        if self.fill_value != lib.no_default:
+        if self.fill_value is not None:
             X.fillna(self.fill_value, inplace=True)
 
         if self.drop_original:

--- a/feature_engine/timeseries/forecasting/lag_features.py
+++ b/feature_engine/timeseries/forecasting/lag_features.py
@@ -164,7 +164,6 @@ class LagFeatures(BaseForecastTransformer):
                     tmp = X[self.variables_].shift(
                         freq=fr,
                         axis=0,
-                        fill_value=self.fill_value,
                     )
                     df_ls.append(tmp)
                 tmp = pd.concat(df_ls, axis=1)
@@ -173,7 +172,6 @@ class LagFeatures(BaseForecastTransformer):
                 tmp = X[self.variables_].shift(
                     freq=self.freq,
                     axis=0,
-                    fill_value=self.fill_value,
                 )
 
         else:
@@ -183,7 +181,6 @@ class LagFeatures(BaseForecastTransformer):
                     tmp = X[self.variables_].shift(
                         periods=pr,
                         axis=0,
-                        fill_value=self.fill_value,
                     )
                     df_ls.append(tmp)
                 tmp = pd.concat(df_ls, axis=1)
@@ -192,12 +189,15 @@ class LagFeatures(BaseForecastTransformer):
                 tmp = X[self.variables_].shift(
                     periods=self.periods,
                     axis=0,
-                    fill_value=self.fill_value,
                 )
 
         tmp.columns = self._get_new_features_name()
 
         X = X.merge(tmp, left_index=True, right_index=True, how="left")
+
+        # if user passes a fill_value, fill NaN
+        if self.fill_value != lib.no_default:
+            X.fillna(self.fill_value, inplace=True)
 
         if self.drop_original:
             X = X.drop(self.variables_, axis=1)

--- a/feature_engine/timeseries/forecasting/lag_features.py
+++ b/feature_engine/timeseries/forecasting/lag_features.py
@@ -132,9 +132,7 @@ class LagFeatures(BaseForecastTransformer):
                 "sort_index takes values True and False." f"Got {sort_index} instead."
             )
 
-        super().__init__(
-            variables, missing_values, drop_original, fill_value
-        )
+        super().__init__(variables, fill_value, missing_values, drop_original)
 
         self.periods = periods
         self.freq = freq

--- a/feature_engine/timeseries/forecasting/window_features.py
+++ b/feature_engine/timeseries/forecasting/window_features.py
@@ -9,9 +9,9 @@ from feature_engine._docstrings.fit_attributes import (
 )
 from feature_engine._docstrings.init_parameters import (
     _drop_original_docstring,
-    _fill_value_docstring,
     _missing_values_docstring,
     _variables_numerical_docstring,
+    _fill_value_docstring,
 )
 from feature_engine._docstrings.methods import (
     _fit_not_learn_docstring,
@@ -103,6 +103,7 @@ class WindowFeatures(BaseForecastTransformer):
 
     {drop_original}
 
+
     Attributes
     ----------
     variables_:
@@ -160,7 +161,7 @@ class WindowFeatures(BaseForecastTransformer):
                 f"periods must be a positive integer. Got {periods} instead."
             )
 
-        super().__init__(variables, missing_values, drop_original, fill_value)
+        super().__init__(variables, fill_value, missing_values, drop_original)
 
         self.window = window
         self.min_periods = min_periods

--- a/feature_engine/timeseries/forecasting/window_features.py
+++ b/feature_engine/timeseries/forecasting/window_features.py
@@ -137,7 +137,7 @@ class WindowFeatures(BaseForecastTransformer):
         periods: int = 1,
         freq: str = None,
         sort_index: bool = True,
-        fill_value: Union[None, int, float, str] = None,,
+        fill_value: Union[None, int, float, str] = None,
         missing_values: str = "raise",
         drop_original: bool = False,
     ) -> None:

--- a/feature_engine/timeseries/forecasting/window_features.py
+++ b/feature_engine/timeseries/forecasting/window_features.py
@@ -193,11 +193,7 @@ class WindowFeatures(BaseForecastTransformer):
                     X[self.variables_]
                     .rolling(window=win)
                     .agg(self.functions)
-                    .shift(
-                        periods=self.periods,
-                        freq=self.freq,
-                        fill_value=self.fill_value
-                    )
+                    .shift(periods=self.periods, freq=self.freq, fill_value=self.fill_value)
                 )
                 df_ls.append(tmp)
             tmp = pd.concat(df_ls, axis=1)
@@ -207,11 +203,7 @@ class WindowFeatures(BaseForecastTransformer):
                 X[self.variables_]
                 .rolling(window=self.window)
                 .agg(self.functions)
-                .shift(
-                    periods=self.periods,
-                    freq=self.freq,
-                    fill_value=self.fill_value
-                )
+                .shift(periods=self.periods, freq=self.freq, fill_value=self.fill_value)
             )
 
         tmp.columns = self._get_new_features_name()

--- a/tests/test_time_series/test_forecasting/test_lag_features.py
+++ b/tests/test_time_series/test_forecasting/test_lag_features.py
@@ -198,7 +198,7 @@ def test_correct_lag_when_using_freq(df_time):
             axis=1,
         )
     )
-
+    print(df_tr.head())
     # When freq is a list
     transformer = LagFeatures(freq=["1h", "15min"])
     df_tr = transformer.fit_transform(df_time)
@@ -233,3 +233,30 @@ def test_sort_index(df_time):
     A = Xs[transformer.variables_].iloc[0:4].values
     B = X_tr[transformer._get_new_features_name()].iloc[1:5].values
     assert (A == B).all()
+
+
+def test_permitted_param_fill_value(df_time):
+
+    expected_results = {
+        "ambient_temp": [31.31, 31.51, 32.15, 32.39, 32.62, 32.5, 32.52],
+        "color": ['blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue'],
+        "irradiation_lag_1h": ['fill', 'fill', 'fill', 'fill', 0.51, 0.79, 0.65],
+        "module_temp_lag_1h": ['fill', 'fill', 'fill', 'fill', 49.18, 49.84, 52.35],
+    }
+
+    expected_results_df = pd.DataFrame(data=expected_results, index=df_time.index[:7])
+
+    # create transformer
+    transformer = LagFeatures(
+        variables=["irradiation", "module_temp"],
+        freq="1h",
+        fill_value="fill",
+        drop_original=True
+    )
+
+    df_tr = transformer.fit_transform(df_time)
+    print(df_tr.head())
+    print(transformer.fill_value)
+    # check results
+    test_df = expected_results_df.head(2).copy()
+    assert df_tr.head(2).equals(test_df)

--- a/tests/test_time_series/test_forecasting/test_lag_features.py
+++ b/tests/test_time_series/test_forecasting/test_lag_features.py
@@ -235,7 +235,7 @@ def test_sort_index(df_time):
     assert (A == B).all()
 
 
-def test_permitted_param_fill_value(df_time):
+def test_permitted_param_fill_value_when_using_freq(df_time):
 
     expected_results = {
         "ambient_temp": [31.31, 31.51, 32.15, 32.39, 32.62, 32.5, 32.52],
@@ -258,5 +258,32 @@ def test_permitted_param_fill_value(df_time):
     print(df_tr.head())
     print(transformer.fill_value)
     # check results
-    test_df = expected_results_df.head(2).copy()
-    assert df_tr.head(2).equals(test_df)
+    test_df = expected_results_df.head().copy()
+    assert df_tr.head().equals(test_df)
+
+
+def test_permitted_param_fill_value_when_using_periods(df_time):
+
+    expected_results = {
+        "module_temp": [49.18, 49.84, 52.35, 50.63, 49.61, 47.01, 46.67],
+        "irradiation": [0.51, 0.79, 0.65, 0.76, 0.42, 0.49, 0.57],
+        "color": ['blue', 'blue', 'blue', 'blue', 'blue', 'blue', 'blue'],
+        "ambient_temp_lag_3": ['fill', 'fill', 'fill', 31.31, 31.51, 32.15, 32.39],
+    }
+
+    expected_results_df = pd.DataFrame(data=expected_results, index=df_time.index[:7])
+
+    # create transformer
+    transformer = LagFeatures(
+        variables="ambient_temp",
+        periods=3,
+        fill_value="fill",
+        drop_original=True
+    )
+
+    df_tr = transformer.fit_transform(df_time)
+    print(df_tr.head())
+    print(transformer.fill_value)
+    # check results
+    test_df = expected_results_df.head().copy()
+    assert df_tr.head().equals(test_df)

--- a/tests/test_time_series/test_forecasting/test_lag_features.py
+++ b/tests/test_time_series/test_forecasting/test_lag_features.py
@@ -282,8 +282,7 @@ def test_permitted_param_fill_value_when_using_periods(df_time):
     )
 
     df_tr = transformer.fit_transform(df_time)
-    print(df_tr.head())
-    print(transformer.fill_value)
+
     # check results
     test_df = expected_results_df.head().copy()
     assert df_tr.head().equals(test_df)

--- a/tests/test_time_series/test_forecasting/test_window_features.py
+++ b/tests/test_time_series/test_forecasting/test_window_features.py
@@ -450,3 +450,28 @@ def test_sort_index(df_time):
     assert_frame_equal(
         df_tr[transformer.variables_], Xs[transformer.variables_].sort_index()
     )
+
+
+def test_fill_value_param(df_time):
+
+    expected_results = {
+        "ambient_temp": [31.31, 31.51, 32.15, 32.39, 32.62, 32.5],
+        "module_temp": [49.18, 49.84, 52.35, 50.63, 49.61, 47.01],
+        "irradiation": [0.51, 0.79, 0.65, 0.76, 0.42, 0.49],
+        "color": ['blue', 'blue', 'blue', 'blue', 'blue', 'blue'],
+        "module_temp_window_3_median": ['fill', 'fill', 'fill', 49.84, 50.63, 50.63],
+        "irradiation_window_3_median": ['fill', 'fill', 'fill', 0.65, 0.76, 0.65],
+    }
+
+    expected_results_df = pd.DataFrame(data=expected_results, index=df_time.index[:6])
+
+    # create transformer
+    transformer = WindowFeatures(
+        variables=["module_temp", "irradiation"],
+        window=3,
+        functions=["median"],
+        fill_value="fill"
+    )
+    df_tr = transformer.fit_transform(df_time)
+
+    assert df_tr.head(6).equals(expected_results_df)

--- a/tests/test_time_series/test_forecasting/test_window_features.py
+++ b/tests/test_time_series/test_forecasting/test_window_features.py
@@ -5,6 +5,7 @@ from pandas.testing import assert_frame_equal
 
 from feature_engine.timeseries.forecasting import WindowFeatures
 
+
 _date_time = [
     pd.Timestamp("2020-05-15 12:00:00"),
     pd.Timestamp("2020-05-15 12:15:00"),
@@ -452,15 +453,17 @@ def test_sort_index(df_time):
     )
 
 
-def test_fill_value_param(df_time):
+def test_fill_value_param_using_periods(df_time):
 
     expected_results = {
         "ambient_temp": [31.31, 31.51, 32.15, 32.39, 32.62, 32.5],
         "module_temp": [49.18, 49.84, 52.35, 50.63, 49.61, 47.01],
         "irradiation": [0.51, 0.79, 0.65, 0.76, 0.42, 0.49],
         "color": ['blue', 'blue', 'blue', 'blue', 'blue', 'blue'],
-        "module_temp_window_3_median": ['fill', 'fill', 'fill', 49.84, 50.63, 50.63],
-        "irradiation_window_3_median": ['fill', 'fill', 'fill', 0.65, 0.76, 0.65],
+        "module_temp_window_4_median": ['fill', 'fill', 'fill', 'fill', 50.24, 50.24],
+        "module_temp_window_4_min": ['fill', 'fill', 'fill', 'fill', 49.18, 49.61],
+        "irradiation_window_4_median": ['fill', 'fill', 'fill', 'fill', 0.70, 0.70],
+        "irradiation_window_4_min": ['fill', 'fill', 'fill', 'fill',  0.51, 0.42],
     }
 
     expected_results_df = pd.DataFrame(data=expected_results, index=df_time.index[:6])
@@ -468,10 +471,11 @@ def test_fill_value_param(df_time):
     # create transformer
     transformer = WindowFeatures(
         variables=["module_temp", "irradiation"],
-        window=3,
-        functions=["median"],
+        window=4,
+        functions=["min"],
         fill_value="fill"
     )
     df_tr = transformer.fit_transform(df_time)
 
-    assert df_tr.head(6).equals(expected_results_df)
+    print(df_tr.head())
+    assert df_tr.head(6).round(2).equals(expected_results_df)

--- a/tests/test_time_series/test_forecasting/test_window_features.py
+++ b/tests/test_time_series/test_forecasting/test_window_features.py
@@ -460,10 +460,10 @@ def test_fill_value_param_using_periods(df_time):
         "module_temp": [49.18, 49.84, 52.35, 50.63, 49.61, 47.01],
         "irradiation": [0.51, 0.79, 0.65, 0.76, 0.42, 0.49],
         "color": ['blue', 'blue', 'blue', 'blue', 'blue', 'blue'],
-        "module_temp_window_4_median": ['fill', 'fill', 'fill', 'fill', 50.24, 50.24],
-        "module_temp_window_4_min": ['fill', 'fill', 'fill', 'fill', 49.18, 49.61],
-        "irradiation_window_4_median": ['fill', 'fill', 'fill', 'fill', 0.70, 0.70],
-        "irradiation_window_4_min": ['fill', 'fill', 'fill', 'fill',  0.51, 0.42],
+        "module_temp_window_4_sum": ['fill', 'fill', 'fill', 'fill', 'fill', 202.0],
+        "module_temp_window_4_min": ['fill', 'fill', 'fill', 'fill', 'fill', 49.18],
+        "irradiation_window_4_sum": ['fill', 'fill', 'fill', 'fill', 'fill', 2.71],
+        "irradiation_window_4_min": ['fill', 'fill', 'fill', 'fill',  'fill', 0.51],
     }
 
     expected_results_df = pd.DataFrame(data=expected_results, index=df_time.index[:6])
@@ -472,10 +472,12 @@ def test_fill_value_param_using_periods(df_time):
     transformer = WindowFeatures(
         variables=["module_temp", "irradiation"],
         window=4,
-        functions=["min"],
-        fill_value="fill"
+        functions=["sum", "min"],
+        periods=2,
+        fill_value="fill",
     )
     df_tr = transformer.fit_transform(df_time)
 
     print(df_tr.head())
     assert df_tr.head(6).round(2).equals(expected_results_df)
+


### PR DESCRIPTION
Closes #536 

Selected Notes from #536:

pandas shift and pandas rolling have a parameter to handle NaN introduced during the operations, we should allow users to tap into that parameter in our transformers.

We need to add a parameter in the init of the LagFeatures, WindowFeatures and ExpandedWindowFeatures that then would be passed onto the fill_value parameter of pandas.shift (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.shift.html) to replace the nan introduced by that value.