### PR TITLE
Update fold default value for outlier class

### DIFF
--- a/feature_engine/outliers/base_outlier.py
+++ b/feature_engine/outliers/base_outlier.py
@@ -170,12 +170,13 @@ class WinsorizerBase(BaseOutlier):
         distribution. Can take 'left', 'right' or 'both'.
         """.rstrip()
 
-    _fold_docstring = """fold: int or float, default=3
+    _fold_docstring = """fold: int or float, default=3 or 0.05 (quantile)
         The factor used to multiply the std, MAD or IQR to calculate
         the maximum or minimum allowed values.
         Recommended values are 2 or 3 for the gaussian approximation,
         1.5 or 3 for the IQR proximity rule and 3 or 3.5 for MAD rule.
 
+        If `capping_method='quantile'`,the fold default=0.05,
         The `'fold'` indicates the percentile.
         eg: if fold=0.05, the limits will be the 95th and 5th percentiles.
 

--- a/feature_engine/outliers/base_outlier.py
+++ b/feature_engine/outliers/base_outlier.py
@@ -170,15 +170,16 @@ class WinsorizerBase(BaseOutlier):
         distribution. Can take 'left', 'right' or 'both'.
         """.rstrip()
 
-    _fold_docstring = """fold: int or float, default=3
+    _fold_docstring = """fold: int or float, default=3 or 0.05 (quantile)
         The factor used to multiply the std, MAD or IQR to calculate
         the maximum or minimum allowed values.
         Recommended values are 2 or 3 for the gaussian approximation,
         1.5 or 3 for the IQR proximity rule and 3 or 3.5 for MAD rule.
 
-        If `capping_method='quantile'`, then `'fold'` indicates the percentile. So if
-        `fold=0.05`, the limits will be the 95th and 5th percentiles.
-
+        If `capping_method='quantile'`,the fold default=0.05,
+        The `'fold'` indicates the percentile.
+        eg: if fold=0.05, the limits will be the 95th and 5th percentiles.
+        
         **Note**: Outliers will be removed up to a maximum of the 20th percentiles on
         both sides. Thus, when `capping_method='quantile'`, then `'fold'` takes values
         between 0 and 0.20.
@@ -215,7 +216,7 @@ class WinsorizerBase(BaseOutlier):
 
         self.capping_method = capping_method
         self.tail = tail
-        self.fold = fold
+        self.fold = 0.05 if (capping_method == "quantiles") & (fold == 3) else fold
         self.variables = _check_init_parameter_variables(variables)
         self.missing_values = missing_values
 

--- a/feature_engine/outliers/base_outlier.py
+++ b/feature_engine/outliers/base_outlier.py
@@ -170,15 +170,14 @@ class WinsorizerBase(BaseOutlier):
         distribution. Can take 'left', 'right' or 'both'.
         """.rstrip()
 
-    _fold_docstring = """fold: int or float, default=3 or 0.05 (quantile)
+    _fold_docstring = """fold: int or float, default=3
         The factor used to multiply the std, MAD or IQR to calculate
         the maximum or minimum allowed values.
         Recommended values are 2 or 3 for the gaussian approximation,
         1.5 or 3 for the IQR proximity rule and 3 or 3.5 for MAD rule.
 
-        If `capping_method='quantile'`,the fold default=0.05,
-        The `'fold'` indicates the percentile.
-        eg: if fold=0.05, the limits will be the 95th and 5th percentiles.
+        If `capping_method='quantile'`, then `'fold'` indicates the percentile. So if
+        `fold=0.05`, the limits will be the 95th and 5th percentiles.
 
         **Note**: Outliers will be removed up to a maximum of the 20th percentiles on
         both sides. Thus, when `capping_method='quantile'`, then `'fold'` takes values

--- a/feature_engine/outliers/base_outlier.py
+++ b/feature_engine/outliers/base_outlier.py
@@ -216,7 +216,7 @@ class WinsorizerBase(BaseOutlier):
 
         self.capping_method = capping_method
         self.tail = tail
-        self.fold = 0.05 if (capping_method=="quantiles") & (fold==3) else fold
+        self.fold = fold
         self.variables = _check_init_parameter_variables(variables)
         self.missing_values = missing_values
 

--- a/feature_engine/outliers/base_outlier.py
+++ b/feature_engine/outliers/base_outlier.py
@@ -176,8 +176,8 @@ class WinsorizerBase(BaseOutlier):
         Recommended values are 2 or 3 for the gaussian approximation,
         1.5 or 3 for the IQR proximity rule and 3 or 3.5 for MAD rule.
 
-        If `capping_method='quantile'`, then `'fold'` indicates the percentile. So if
-        `fold=0.05`, the limits will be the 95th and 5th percentiles.
+        The `'fold'` indicates the percentile.
+        eg: if fold=0.05, the limits will be the 95th and 5th percentiles.
 
         **Note**: Outliers will be removed up to a maximum of the 20th percentiles on
         both sides. Thus, when `capping_method='quantile'`, then `'fold'` takes values
@@ -215,7 +215,7 @@ class WinsorizerBase(BaseOutlier):
 
         self.capping_method = capping_method
         self.tail = tail
-        self.fold = fold
+        self.fold = 0.05 if (capping_method=="quantiles") & (fold==3) else fold
         self.variables = _check_init_parameter_variables(variables)
         self.missing_values = missing_values
 


### PR DESCRIPTION
**This change is not necessary, but make this function more friendly.**

Changed default value of fold to 0.05 when the capping_method='quantile', for other methods, keep the default as 3.

Past :
```
OutlierTrimmer(capping_method='quantile')
OutlierTrimmer.fit(X)
will raise error due to default fold is 3.
```
For now:
```
OutlierTrimmer(capping_method='quantile')
OutlierTrimmer.fit(X)
Will work,
```