### PR TITLE
Update baseoutlier default fold value

### DIFF
--- a/feature_engine/outliers/base_outlier.py
+++ b/feature_engine/outliers/base_outlier.py
@@ -149,9 +149,7 @@ class WinsorizerBase(BaseOutlier):
 
     If `capping_method='mad'` fold is the value to multiply the MAD.
 
-    If `capping_method='quantiles'`, fold is the percentile on each tail that should
-    be censored. For example, if fold=0.05, the limits will be the 5th and 95th
-    percentiles. If fold=0.1, the limits will be the 10th and 90th percentiles.
+    If `capping_method='quantiles'`, check unit_test
     """.rstrip()
 
     _capping_method_docstring = """capping_method: str, default='gaussian'


### PR DESCRIPTION
**This change is not necessary, but make this function more friendly.**

Changed default value of fold to 0.05 when the capping_method='quantile', for other methods, keep the default as 3.

Past :
```
OutlierTrimmer(capping_method='quantile')
OutlierTrimmer.fit(X)
will raise error due to default fold is 3.
```
For now:
```
OutlierTrimmer(capping_method='quantile')
OutlierTrimmer.fit(X)
Will work,
```