### PR TITLE
fixed bug in drop_features

### DIFF
--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -199,6 +199,7 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
         variables: Union[None, int, str, List[Union[str, int]]] = None,
         ignore_format: bool = False,
     ) -> None:
+
         super().__init__(variables, ignore_format)
         self.encoding_method = encoding_method
         self.cv = cv

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -199,7 +199,6 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
         variables: Union[None, int, str, List[Union[str, int]]] = None,
         ignore_format: bool = False,
     ) -> None:
-
         super().__init__(variables, ignore_format)
         self.encoding_method = encoding_method
         self.cv = cv

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -2,12 +2,12 @@ from typing import List, Union
 
 import pandas as pd
 
-from feature_engine.dataframe_checks import check_X
-from feature_engine.selection.base_selector import BaseSelector
-from feature_engine.tags import _return_tags
 from feature_engine._variable_handling.variable_type_selection import (
     _find_all_variables,
 )
+from feature_engine.dataframe_checks import check_X
+from feature_engine.selection.base_selector import BaseSelector
+from feature_engine.tags import _return_tags
 
 
 class DropFeatures(BaseSelector):

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -81,7 +81,7 @@ class DropFeatures(BaseSelector):
         # present in the df.
         X[self.features_to_drop]
 
-        self.features_to_drop_ = _find_all_variables(X,variables=self.features_to_drop)
+        self.features_to_drop_ = _find_all_variables(X, variables=self.features_to_drop)
         # self.features_to_drop_ = self.features_to_drop
 
         # check user is not removing all columns in the dataframe

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -5,7 +5,10 @@ import pandas as pd
 from feature_engine.dataframe_checks import check_X
 from feature_engine.selection.base_selector import BaseSelector
 from feature_engine.tags import _return_tags
-from feature_engine._variable_handling.variable_type_selection import _find_all_variables
+from feature_engine._variable_handling.variable_type_selection import (
+    _find_all_variables,
+)
+
 
 class DropFeatures(BaseSelector):
     """
@@ -54,7 +57,6 @@ class DropFeatures(BaseSelector):
     """
 
     def __init__(self, features_to_drop: List[Union[str, int]]):
-
         if not isinstance(features_to_drop, (str, list)) or len(features_to_drop) == 0:
             raise ValueError(
                 f"features_to_drop should be a list with the name of the variables "
@@ -81,8 +83,8 @@ class DropFeatures(BaseSelector):
         # present in the df.
         X[self.features_to_drop]
 
-        self.features_to_drop_ = _find_all_variables(X, variables=self.features_to_drop)
-        # self.features_to_drop_ = self.features_to_drop
+        self.features_to_drop_ = _find_all_variables(X, 
+                                                    variables=self.features_to_drop)
 
         # check user is not removing all columns in the dataframe
         if len(self.features_to_drop_) == len(X.columns):
@@ -107,3 +109,4 @@ class DropFeatures(BaseSelector):
             "check_fit2d_1feature"
         ] = "the transformer raises an error when removing the only column, ok to fail"
         return tags_dict
+

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -83,8 +83,7 @@ class DropFeatures(BaseSelector):
         # present in the df.
         X[self.features_to_drop]
 
-        self.features_to_drop_ = _find_all_variables(X, 
-                                                    variables=self.features_to_drop)
+        self.features_to_drop_ = _find_all_variables(X, variables=self.features_to_drop)
 
         # check user is not removing all columns in the dataframe
         if len(self.features_to_drop_) == len(X.columns):
@@ -109,4 +108,3 @@ class DropFeatures(BaseSelector):
             "check_fit2d_1feature"
         ] = "the transformer raises an error when removing the only column, ok to fail"
         return tags_dict
-

--- a/feature_engine/selection/drop_features.py
+++ b/feature_engine/selection/drop_features.py
@@ -5,7 +5,7 @@ import pandas as pd
 from feature_engine.dataframe_checks import check_X
 from feature_engine.selection.base_selector import BaseSelector
 from feature_engine.tags import _return_tags
-
+from feature_engine._variable_handling.variable_type_selection import _find_all_variables
 
 class DropFeatures(BaseSelector):
     """
@@ -81,10 +81,11 @@ class DropFeatures(BaseSelector):
         # present in the df.
         X[self.features_to_drop]
 
-        self.features_to_drop_ = self.features_to_drop
+        self.features_to_drop_ = _find_all_variables(X,variables=self.features_to_drop)
+        # self.features_to_drop_ = self.features_to_drop
 
         # check user is not removing all columns in the dataframe
-        if len(self.features_to_drop) == len(X.columns):
+        if len(self.features_to_drop_) == len(X.columns):
             raise ValueError(
                 "The resulting dataframe will have no columns after dropping all "
                 "existing variables"

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -34,7 +34,6 @@ def test_drop_1_variable(df_vartypes):
     assert type(X) == pd.DataFrame
 
 
-
 def test_drop_2_variables(df_vartypes):
     transformer = DropFeatures(features_to_drop=["City", "dob"])
     X = transformer.fit_transform(df_vartypes)
@@ -95,4 +94,3 @@ def test_drop_2_variables_integer_colnames(df_numeric_columns):
     assert transformer.features_to_drop == [0, 1]
     # transform params
     pd.testing.assert_frame_equal(X, df)
-

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -28,7 +28,8 @@ def test_drop_1_variable(df_vartypes):
 
 
 def test_drop_1_variables_str_input(df_vartypes):
-    """check that the internal variable features_to_drop has been correctly cast from :str: to list of :str: internally"""
+    """check that the internal variable features_to_drop has been
+     correctly cast from :str: to list of :str: internally"""
 
     transformer = DropFeatures(features_to_drop="Marks")
     X = transformer.fit_transform(df_vartypes)

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -26,12 +26,30 @@ def test_drop_1_variable(df_vartypes):
     assert type(X) == pd.DataFrame
     pd.testing.assert_frame_equal(X, df)
 
-    # checking features_to_drop has been correctly cast to list of str internally
-    transformer = DropFeatures(features_to_drop='Marks')
+
+def test_drop_1_variables_str_input(df_vartypes):
+    """check that the internal variable features_to_drop has been correctly cast from :str: to list of :str: internally"""
+
+    transformer = DropFeatures(features_to_drop="Marks")
     X = transformer.fit_transform(df_vartypes)
-    assert X.shape == (4, 4)
+
+    # expected result
+    df = pd.DataFrame(
+        {
+            "Name": ["tom", "nick", "krish", "jack"],
+            "City": ["London", "Manchester", "Liverpool", "Bristol"],
+            "Age": [20, 21, 19, 18],
+            "dob": pd.date_range("2020-02-24", periods=4, freq="T"),
+        }
+    )
+
+    # init params
     assert transformer.features_to_drop == "Marks"
+
+    # transform params
+    assert X.shape == (4, 4)
     assert type(X) == pd.DataFrame
+    pd.testing.assert_frame_equal(X, df)
 
 
 def test_drop_2_variables(df_vartypes):

--- a/tests/test_selection/test_drop_features.py
+++ b/tests/test_selection/test_drop_features.py
@@ -26,6 +26,14 @@ def test_drop_1_variable(df_vartypes):
     assert type(X) == pd.DataFrame
     pd.testing.assert_frame_equal(X, df)
 
+    # checking features_to_drop has been correctly cast to list of str internally
+    transformer = DropFeatures(features_to_drop='Marks')
+    X = transformer.fit_transform(df_vartypes)
+    assert X.shape == (4, 4)
+    assert transformer.features_to_drop == "Marks"
+    assert type(X) == pd.DataFrame
+
+
 
 def test_drop_2_variables(df_vartypes):
     transformer = DropFeatures(features_to_drop=["City", "dob"])
@@ -87,3 +95,4 @@ def test_drop_2_variables_integer_colnames(df_numeric_columns):
     assert transformer.features_to_drop == [0, 1]
     # transform params
     pd.testing.assert_frame_equal(X, df)
+


### PR DESCRIPTION
Hi,

I found a bug in the DropFeatures transformer, module drop_features.py. The check (number of columns) in the .fit() method may fail unintentionally if features_to_drop is a string.

```
from feature_engine.selection import DropFeatures
import pandas as pd

df = pd.DataFrame({'aa':[1,2], 'bb': [3,4]})
transformer = DropFeatures(features_to_drop="aa")
X = transformer.fit_transform(df)

```

To fix this, I´ve applied the conversion of features_to_drop using the _find_all_variables method.
