### PR TITLE
Add code examples in preprocessing and wrappers modules' docstrings

### DIFF
--- a/feature_engine/preprocessing/match_categories.py
+++ b/feature_engine/preprocessing/match_categories.py
@@ -88,6 +88,29 @@ class MatchCategories(
 
     transform:
         Enforce the type of categorical variables as dtype `categorical`.
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.preprocessing import MatchCategories
+    >>> X_train = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [4,5,6]))
+    >>> X_test = pd.DataFrame(dict(x1 = ["c","b","a","d"], x2 = [5,6,4,7]))
+    >>> mc = MatchCategories(missing_values="ignore")
+    >>> mc.fit(X_train)
+    >>> mc.transform(X_train)
+      x1  x2
+    0  a   4
+    1  b   5
+    2  c   6
+    >>> mc.transform(X_test)
+        x1  x2
+    0    c   5
+    1    b   6
+    2    a   4
+    3  NaN   7
+
+
     """
 
     def __init__(

--- a/feature_engine/preprocessing/match_categories.py
+++ b/feature_engine/preprocessing/match_categories.py
@@ -109,8 +109,6 @@ class MatchCategories(
     1    b   6
     2    a   4
     3  NaN   7
-
-
     """
 
     def __init__(

--- a/feature_engine/preprocessing/match_columns.py
+++ b/feature_engine/preprocessing/match_columns.py
@@ -127,11 +127,9 @@ class MatchVariables(BaseEstimator, TransformerMixin, GetFeatureNamesOutMixin):
 
     >>> import pandas as pd
     >>> from feature_engine.preprocessing import MatchVariables
-
     >>> X_train = pd.DataFrame(dict(x1 = ["a","b","c"],
     >>>                             x2 = [4,5,6], x3 = [1,1,1]))
     >>> X_test = pd.DataFrame(dict(x1 = ["c","b","a","d"], x2 = [5,6,4,7]))
-
     >>> mv = MatchVariables(missing_values="ignore")
     >>> mv.fit(X_train)
     >>> mv.transform(X_train)

--- a/feature_engine/preprocessing/match_columns.py
+++ b/feature_engine/preprocessing/match_columns.py
@@ -100,6 +100,52 @@ class MatchVariables(BaseEstimator, TransformerMixin, GetFeatureNamesOutMixin):
 
     transform:
         Add or delete variables to match those observed in the train set.
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.preprocessing import MatchVariables
+    >>> X_train = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [4,5,6]))
+    >>> X_test = pd.DataFrame(dict(x1 = ["c","b","a","d"],
+    >>>                             x2 = [5,6,4,7],
+    >>>                             x3 = [1,1,1,1]))
+    >>> mv = MatchVariables(missing_values="ignore")
+    >>> mv.fit(X_train)
+    >>> mv.transform(X_train)
+    x1  x2
+    0  a   4
+    1  b   5
+    2  c   6
+    >>> mv.transform(X_test)
+    The following variables are dropped from the DataFrame: ['x3']
+      x1  x2
+    0  c   5
+    1  b   6
+    2  a   4
+    3  d   7
+
+    >>> import pandas as pd
+    >>> from feature_engine.preprocessing import MatchVariables
+
+    >>> X_train = pd.DataFrame(dict(x1 = ["a","b","c"],
+    >>>                             x2 = [4,5,6], x3 = [1,1,1]))
+    >>> X_test = pd.DataFrame(dict(x1 = ["c","b","a","d"], x2 = [5,6,4,7]))
+
+    >>> mv = MatchVariables(missing_values="ignore")
+    >>> mv.fit(X_train)
+    >>> mv.transform(X_train)
+      x1  x2  x3
+    0  a   4   1
+    1  b   5   1
+    2  c   6   1
+    >>> mv.transform(X_test)
+    The following variables are added to the DataFrame: ['x3']
+      x1  x2  x3
+    0  c   5 NaN
+    1  b   6 NaN
+    2  a   4 NaN
+    3  d   7 NaN
     """
 
     def __init__(

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -151,38 +151,38 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
     >>> import pandas as pd
     >>> from feature_engine.wrappers import SklearnTransformerWrapper
     >>> from sklearn.preprocessing import StandardScaler
-    >>> X = pd.DataFrame(dict(x1 = [1,2,3], x2 = [4,5,6]))
+    >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
     >>> skw = SklearnTransformerWrapper(StandardScaler())
     >>> skw.fit(X)
     >>> skw.transform(X)
-             x1        x2
-    0 -1.224745 -1.224745
-    1  0.000000  0.000000
-    2  1.224745  1.224745
+      x1        x2        x3
+    0  a -1.224745 -1.224745
+    1  b  0.000000  0.000000
+    2  c  1.224745  1.224745
 
     >>> import pandas as pd
     >>> from feature_engine.wrappers import SklearnTransformerWrapper
     >>> from sklearn.preprocessing import OneHotEncoder
-    >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [4,5,6]))
-    >>> skw = SklearnTransformerWrapper(OneHotEncoder(sparse = False),
-    >>>                                 variables = "x1")
+    >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
+    >>> skw = SklearnTransformerWrapper(OneHotEncoder(sparse = False), variables = "x1")
     >>> skw.fit(X)
     >>> skw.transform(X)
-       x2  x1_a  x1_b  x1_c
-    0   4   1.0   0.0   0.0
-    1   5   0.0   1.0   0.0
-    2   6   0.0   0.0   1.0
+       x2  x3  x1_a  x1_b  x1_c
+    0   1   4   1.0   0.0   0.0
+    1   2   5   0.0   1.0   0.0
+    2   3   6   0.0   0.0   1.0
 
     >>> import pandas as pd
     >>> from feature_engine.wrappers import SklearnTransformerWrapper
     >>> from sklearn.preprocessing import PolynomialFeatures
+    >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
     >>> skw = SklearnTransformerWrapper(PolynomialFeatures(include_bias = False))
     >>> skw.fit(X)
     >>> skw.transform(X)
-      x1   x2  x2^2
-    0  a  4.0  16.0
-    1  b  5.0  25.0
-    2  c  6.0  36.0
+      x1   x2   x3  x2^2  x2 x3  x3^2
+    0  a  1.0  4.0   1.0    4.0  16.0
+    1  b  2.0  5.0   4.0   10.0  25.0
+    2  c  3.0  6.0   9.0   18.0  36.0
     """
 
     def __init__(

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -164,7 +164,8 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
     >>> from feature_engine.wrappers import SklearnTransformerWrapper
     >>> from sklearn.preprocessing import OneHotEncoder
     >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
-    >>> skw = SklearnTransformerWrapper(OneHotEncoder(sparse = False), variables = "x1")
+    >>> skw = SklearnTransformerWrapper(
+    >>>     OneHotEncoder(sparse_output = False), variables = "x1")
     >>> skw.fit(X)
     >>> skw.transform(X)
        x2  x3  x1_a  x1_b  x1_c

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -144,6 +144,45 @@ class SklearnTransformerWrapper(BaseEstimator, TransformerMixin):
     See Also
     --------
     sklearn.compose.ColumnTransformer
+
+    Examples
+    --------
+
+    >>> import pandas as pd
+    >>> from feature_engine.wrappers import SklearnTransformerWrapper
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3], x2 = [4,5,6]))
+    >>> skw = SklearnTransformerWrapper(StandardScaler())
+    >>> skw.fit(X)
+    >>> skw.transform(X)
+             x1        x2
+    0 -1.224745 -1.224745
+    1  0.000000  0.000000
+    2  1.224745  1.224745
+
+    >>> import pandas as pd
+    >>> from feature_engine.wrappers import SklearnTransformerWrapper
+    >>> from sklearn.preprocessing import OneHotEncoder
+    >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [4,5,6]))
+    >>> skw = SklearnTransformerWrapper(OneHotEncoder(sparse = False),
+    >>>                                 variables = "x1")
+    >>> skw.fit(X)
+    >>> skw.transform(X)
+       x2  x1_a  x1_b  x1_c
+    0   4   1.0   0.0   0.0
+    1   5   0.0   1.0   0.0
+    2   6   0.0   0.0   1.0
+
+    >>> import pandas as pd
+    >>> from feature_engine.wrappers import SklearnTransformerWrapper
+    >>> from sklearn.preprocessing import PolynomialFeatures
+    >>> skw = SklearnTransformerWrapper(PolynomialFeatures(include_bias = False))
+    >>> skw.fit(X)
+    >>> skw.transform(X)
+      x1   x2  x2^2
+    0  a  4.0  16.0
+    1  b  5.0  25.0
+    2  c  6.0  36.0
     """
 
     def __init__(


### PR DESCRIPTION
Added examples for the following modules (both in the same PR because they are just a few classes).

- Wrappers: `SklearnTransformerWrapper`
-  Preprocessing: `MatchCategories` and `MatchVariables`.