### PR TITLE
return name of variables with 0s in denominator in woe encoder

### DIFF
--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -53,7 +53,13 @@ class WoE:
             y = pd.Series(np.where(y == y.min(), 0, 1))
         return X, y
 
-    def _calculate_woe(self, X: pd.DataFrame, y: pd.Series, variable: Union[str, int], fill_value: Union[float, None] = None):
+    def _calculate_woe(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        variable: Union[str, int],
+        fill_value: Union[float, None] = None,
+    ):
         total_pos = y.sum()
         inverse_y = y.ne(1).copy()
         total_neg = inverse_y.sum()
@@ -65,11 +71,13 @@ class WoE:
             if fill_value is None:
                 raise ValueError(
                     "The proportion of one of the classes for a category in "
-                    "variable {} is zero, and log of zero is not defined".format(variable)
+                    "variable {} is zero, and log of zero is not defined".format(
+                        variable
+                    )
                 )
             else:
-                pos[pos[:]==0] = fill_value
-                neg[neg[:]==0] = fill_value
+                pos[pos[:] == 0] = fill_value
+                neg[neg[:] == 0] = fill_value
 
         woe = np.log(pos / neg)
         return pos, neg, woe

--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -201,7 +201,7 @@ class WoEEncoder(CategoricalInitMixin, CategoricalMethodsMixin, WoE):
         variables: Union[None, int, str, List[Union[str, int]]] = None,
         ignore_format: bool = False,
         unseen: str = "ignore",
-        fill_value: Union[int, float] = None,
+        fill_value: Union[int, float, None] = None,
     ) -> None:
 
         super().__init__(variables, ignore_format)

--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -53,7 +53,7 @@ class WoE:
             y = pd.Series(np.where(y == y.min(), 0, 1))
         return X, y
 
-    def _calculate_woe(self, X: pd.DataFrame, y: pd.Series, variable: Union[str, int]):
+    def _calculate_woe(self, X: pd.DataFrame, y: pd.Series, variable: Union[str, int], fill_value: Union[float, None] = None):
         total_pos = y.sum()
         inverse_y = y.ne(1).copy()
         total_neg = inverse_y.sum()
@@ -62,10 +62,14 @@ class WoE:
         neg = inverse_y.groupby(X[variable]).sum() / total_neg
 
         if not (pos[:] == 0).sum() == 0 or not (neg[:] == 0).sum() == 0:
-            raise ValueError(
-                "The proportion of one of the classes for a category in "
-                "variable {} is zero, and log of zero is not defined".format(variable)
-            )
+            if fill_value is None:
+                raise ValueError(
+                    "The proportion of one of the classes for a category in "
+                    "variable {} is zero, and log of zero is not defined".format(variable)
+                )
+            else:
+                pos[pos[:]==0] = fill_value
+                neg[neg[:]==0] = fill_value
 
         woe = np.log(pos / neg)
         return pos, neg, woe

--- a/feature_engine/encoding/woe.py
+++ b/feature_engine/encoding/woe.py
@@ -206,6 +206,10 @@ class WoEEncoder(CategoricalInitMixin, CategoricalMethodsMixin, WoE):
 
         super().__init__(variables, ignore_format)
         check_parameter_unseen(unseen, ["ignore", "raise"])
+        if fill_value is not None and not isinstance(fill_value, (int, float)):
+            raise ValueError(
+                f"fill_value takes None, integer or float. Got {fill_value} instead."
+            )
         self.unseen = unseen
         self.fill_value = fill_value
 

--- a/tests/test_encoding/test_woe/test_woe_class.py
+++ b/tests/test_encoding/test_woe/test_woe_class.py
@@ -28,3 +28,39 @@ def test_woe_error():
 
     with pytest.raises(ValueError):
         woe_class._calculate_woe(df, df["target"], "var_A")
+
+
+@pytest.mark.parametrize("fill_value", [1, 10, 0.1])
+def test_fill_value(fill_value):
+    df = {
+        "var_A": ["A"] * 9 + ["B"] * 6 + ["C"] * 3 + ["D"] * 2,
+        "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "target": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
+
+    pos_exp = pd.Series(
+        {
+            "A": 0.2857142857142857,
+            "B": 0.2857142857142857,
+            "C": 0.42857142857142855,
+            "D": fill_value,
+        }
+    )
+    neg_exp = pd.Series(
+        {
+            "A": 0.5384615384615384,
+            "B": 0.3076923076923077,
+            "C": fill_value,
+            "D": 0.15384615384615385,
+        }
+    )
+
+    woe_class = WoE()
+    pos, neg, woe = woe_class._calculate_woe(
+        df, df["target"], "var_A", fill_value=fill_value
+    )
+
+    pd.testing.assert_series_equal(pos, pos_exp, check_names=False)
+    pd.testing.assert_series_equal(neg, neg_exp, check_names=False)
+    pd.testing.assert_series_equal(np.log(pos / neg), woe, check_names=False)

--- a/tests/test_encoding/test_woe/test_woe_class.py
+++ b/tests/test_encoding/test_woe/test_woe_class.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from feature_engine.encoding.woe import WoE
 
@@ -14,3 +15,16 @@ def test_woe_calculation(df_enc):
     pd.testing.assert_series_equal(pos, pos_exp, check_names=False)
     pd.testing.assert_series_equal(neg, neg_exp, check_names=False)
     pd.testing.assert_series_equal(np.log(pos / neg), woe, check_names=False)
+
+
+def test_woe_error():
+    df = {
+        "var_A": ["B"] * 9 + ["A"] * 6 + ["C"] * 3 + ["D"] * 2,
+        "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "target": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
+    woe_class = WoE()
+
+    with pytest.raises(ValueError):
+        woe_class._calculate_woe(df, df["target"], "var_A")

--- a/tests/test_encoding/test_woe/test_woe_class.py
+++ b/tests/test_encoding/test_woe/test_woe_class.py
@@ -14,7 +14,7 @@ def test_woe_calculation(df_enc):
 
     pd.testing.assert_series_equal(pos, pos_exp, check_names=False)
     pd.testing.assert_series_equal(neg, neg_exp, check_names=False)
-    pd.testing.assert_series_equal(np.log(pos / neg), woe, check_names=False)
+    pd.testing.assert_series_equal(np.log(pos_exp / neg_exp), woe, check_names=False)
 
 
 def test_woe_error():
@@ -63,4 +63,4 @@ def test_fill_value(fill_value):
 
     pd.testing.assert_series_equal(pos, pos_exp, check_names=False)
     pd.testing.assert_series_equal(neg, neg_exp, check_names=False)
-    pd.testing.assert_series_equal(np.log(pos / neg), woe, check_names=False)
+    pd.testing.assert_series_equal(np.log(pos_exp / neg_exp), woe, check_names=False)

--- a/tests/test_encoding/test_woe/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe/test_woe_encoder.py
@@ -233,23 +233,36 @@ def test_error_if_denominator_probability_is_zero_2_vars():
     )
     assert str(record.value) == msg
 
-    # # # test case 6: when the numerator probability is zero, woe
-    # # with pytest.raises(ValueError):
-    # #     df = {'var_A': ['A'] * 6 + ['B'] * 10 + ['C'] * 4,
-    # #           'var_B': ['A'] * 10 + ['B'] * 6 + ['C'] * 4,
-    # #           'target': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
-    # 1, 0, 0]}
-    # #     df = pd.DataFrame(df)
-    # #     encoder.fit(df[['var_A', 'var_B']], df['target'])
-    #
-    # # # test case 7: when the denominator probability is zero, woe
-    # # with pytest.raises(ValueError):
-    # #     df = {'var_A': ['A'] * 6 + ['B'] * 10 + ['C'] * 4,
-    # #           'var_B': ['A'] * 10 + ['B'] * 6 + ['C'] * 4,
-    # #           'target': [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1,
-    # 0, 0]}
-    # #     df = pd.DataFrame(df)
-    # #     encoder.fit(df[['var_A', 'var_B']], df['target'])
+
+def test_error_if_numerator_probability_is_zero():
+    df = {
+        "var_A": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
+        "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "var_C": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
+        "target": [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
+    encoder = WoEEncoder(variables=None)
+
+    with pytest.raises(ValueError) as record:
+        encoder.fit(df, df["target"])
+
+    msg = (
+        "During the WoE calculation, some of the categories in the "
+        "following features contained 0 in the denominator or numerator, "
+        "and hence the WoE can't be calculated: var_A, var_C."
+    )
+    assert str(record.value) == msg
+
+    with pytest.raises(ValueError) as record:
+        encoder.fit(df[["var_A", "var_B"]], df["target"])
+
+    msg = (
+        "During the WoE calculation, some of the categories in the "
+        "following features contained 0 in the denominator or numerator, "
+        "and hence the WoE can't be calculated: var_A."
+    )
+    assert str(record.value) == msg
 
 
 def test_error_if_contains_na_in_fit(df_enc_na):

--- a/tests/test_encoding/test_woe/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe/test_woe_encoder.py
@@ -313,7 +313,7 @@ def test_error_if_fill_value_not_allowed(fill_value):
         WoEEncoder(fill_value=fill_value)
 
 
-@pytest.mark.parametrize("fill_value", [0, 1, 10, 0.5, 0.002])
+@pytest.mark.parametrize("fill_value", [0, 1, 10, 0.5, 0.002, None])
 def test_assigns_fill_value_at_init(fill_value):
     encoder = WoEEncoder(fill_value=fill_value)
     assert encoder.fill_value == fill_value

--- a/tests/test_encoding/test_woe/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe/test_woe_encoder.py
@@ -301,6 +301,18 @@ def test_fill_value():
     assert encoder.encoder_dict_ == woe_exp
 
 
+@pytest.mark.parametrize("fill_value", ["hola", [10]])
+def test_error_if_fill_value_not_allowed(fill_value):
+    with pytest.raises(ValueError):
+        WoEEncoder(fill_value=fill_value)
+
+
+@pytest.mark.parametrize("fill_value", [0, 1, 10, 0.5, 0.002])
+def test_assigns_fill_value_at_init(fill_value):
+    encoder = WoEEncoder(fill_value=fill_value)
+    assert encoder.fill_value == fill_value
+
+
 def test_error_if_contains_na_in_fit(df_enc_na):
     # test case 9: when dataset contains na, fit method
     encoder = WoEEncoder(variables=None)

--- a/tests/test_encoding/test_woe/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe/test_woe_encoder.py
@@ -265,6 +265,42 @@ def test_error_if_numerator_probability_is_zero():
     assert str(record.value) == msg
 
 
+def test_fill_value():
+    df = {
+        "var_A": ["A"] * 9 + ["B"] * 6 + ["C"] * 3 + ["D"] * 2,
+        "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "target": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
+    encoder = WoEEncoder(variables=None, fill_value=1)
+    encoder.fit(df, df["target"])
+    woe_exp_a = {
+        "A": -0.6337237600891445,
+        "B": -0.07410797215372196,
+        "C": -0.8472978603872037,
+        "D": 1.8718021769015913,
+    }
+    woe_exp_b = {
+        "A": -0.7672551527136673,
+        "B": 0.6190392084062234,
+        "C": 0.6190392084062234,
+    }
+
+    woe_exp = {"var_A": woe_exp_a, "var_B": woe_exp_b}
+    assert encoder.encoder_dict_ == woe_exp
+
+    encoder = WoEEncoder(variables=None, fill_value=10)
+    encoder.fit(df, df["target"])
+    woe_exp_a = {
+        "A": -0.6337237600891445,
+        "B": -0.07410797215372196,
+        "C": -3.1498829533812494,
+        "D": 4.174387269895637,
+    }
+    woe_exp = {"var_A": woe_exp_a, "var_B": woe_exp_b}
+    assert encoder.encoder_dict_ == woe_exp
+
+
 def test_error_if_contains_na_in_fit(df_enc_na):
     # test case 9: when dataset contains na, fit method
     encoder = WoEEncoder(variables=None)

--- a/tests/test_encoding/test_woe/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe/test_woe_encoder.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -285,9 +287,11 @@ def test_fill_value():
         "B": 0.6190392084062234,
         "C": 0.6190392084062234,
     }
-
     woe_exp = {"var_A": woe_exp_a, "var_B": woe_exp_b}
-    assert encoder.encoder_dict_ == woe_exp
+
+    for var in ["var_A", "var_B"]:
+        for k, i in woe_exp[var].items():
+            assert math.isclose(encoder.encoder_dict_[var][k], woe_exp[var][k])
 
     encoder = WoEEncoder(variables=None, fill_value=10)
     encoder.fit(df, df["target"])
@@ -298,7 +302,9 @@ def test_fill_value():
         "D": 4.174387269895637,
     }
     woe_exp = {"var_A": woe_exp_a, "var_B": woe_exp_b}
-    assert encoder.encoder_dict_ == woe_exp
+    for var in ["var_A", "var_B"]:
+        for k, i in woe_exp[var].items():
+            assert math.isclose(encoder.encoder_dict_[var][k], woe_exp[var][k])
 
 
 @pytest.mark.parametrize("fill_value", ["hola", [10]])

--- a/tests/test_encoding/test_woe/test_woe_encoder.py
+++ b/tests/test_encoding/test_woe/test_woe_encoder.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from sklearn.exceptions import NotFittedError
 
 from feature_engine.encoding import WoEEncoder
@@ -176,17 +175,63 @@ def test_error_if_target_not_binary():
         encoder.fit(df[["var_A", "var_B"]], df["target"])
 
 
-def test_error_if_denominator_probability_is_zero():
-    # test case 5: when the denominator probability is zero
+def test_error_if_denominator_probability_is_zero_1_var():
+    df = {
+        "var_A": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
+        "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "target": [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
     encoder = WoEEncoder(variables=None)
-    with pytest.raises(ValueError):
-        df = {
-            "var_A": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
-            "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
-            "target": [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0],
-        }
-        df = pd.DataFrame(df)
+
+    with pytest.raises(ValueError) as record:
         encoder.fit(df[["var_A", "var_B"]], df["target"])
+
+    msg = (
+        "During the WoE calculation, some of the categories in the "
+        "following features contained 0 in the denominator or numerator, "
+        "and hence the WoE can't be calculated: var_A."
+    )
+    assert str(record.value) == msg
+
+    df = {
+        "var_A": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "var_B": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
+        "target": [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
+    encoder = WoEEncoder(variables=None)
+
+    with pytest.raises(ValueError) as record:
+        encoder.fit(df[["var_A", "var_B"]], df["target"])
+
+    msg = (
+        "During the WoE calculation, some of the categories in the "
+        "following features contained 0 in the denominator or numerator, "
+        "and hence the WoE can't be calculated: var_B."
+    )
+    assert str(record.value) == msg
+
+
+def test_error_if_denominator_probability_is_zero_2_vars():
+    df = {
+        "var_A": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
+        "var_B": ["A"] * 10 + ["B"] * 6 + ["C"] * 4,
+        "var_C": ["A"] * 6 + ["B"] * 10 + ["C"] * 4,
+        "target": [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0],
+    }
+    df = pd.DataFrame(df)
+    encoder = WoEEncoder(variables=None)
+
+    with pytest.raises(ValueError) as record:
+        encoder.fit(df, df["target"])
+
+    msg = (
+        "During the WoE calculation, some of the categories in the "
+        "following features contained 0 in the denominator or numerator, "
+        "and hence the WoE can't be calculated: var_A, var_C."
+    )
+    assert str(record.value) == msg
 
     # # # test case 6: when the numerator probability is zero, woe
     # # with pytest.raises(ValueError):


### PR DESCRIPTION
closes #672 
closes #430 
closes #56 

and also
closes #673 