### PR TITLE
Add the inverse_transform method in the yeoJohnson transformer

### DIFF
--- a/feature_engine/transformation/yeojohnson.py
+++ b/feature_engine/transformation/yeojohnson.py
@@ -7,17 +7,21 @@ import numpy as np
 import pandas as pd
 import scipy.stats as stats
 
-from feature_engine._base_transformers.base_numerical import \
+from feature_engine._base_transformers.base_numerical import (
     BaseNumericalTransformer
+)
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring, _n_features_in_docstring,
-    _variables_attribute_docstring)
-from feature_engine._docstrings.init_parameters.all_trasnformers import \
+    _variables_attribute_docstring
+)
+from feature_engine._docstrings.init_parameters.all_trasnformers import (
     _variables_numerical_docstring
+)
 from feature_engine._docstrings.methods import _fit_transform_docstring
 from feature_engine._docstrings.substitute import Substitution
-from feature_engine.variable_handling._init_parameter_checks import \
+from feature_engine.variable_handling._init_parameter_checks import (
     _check_init_parameter_variables
+)
 
 
 @Substitution(

--- a/feature_engine/transformation/yeojohnson.py
+++ b/feature_engine/transformation/yeojohnson.py
@@ -3,6 +3,7 @@
 
 from typing import List, Optional, Union
 
+import numpy as np
 import pandas as pd
 import scipy.stats as stats
 
@@ -103,7 +104,6 @@ class YeoJohnsonTransformer(BaseNumericalTransformer):
     def __init__(
         self, variables: Union[None, int, str, List[Union[str, int]]] = None
     ) -> None:
-
         self.variables = _check_init_parameter_variables(variables)
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
@@ -152,3 +152,45 @@ class YeoJohnsonTransformer(BaseNumericalTransformer):
             X[feature] = stats.yeojohnson(X[feature], lmbda=self.lambda_dict_[feature])
 
         return X
+
+    def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        """
+        Apply the inverse-transform function Yeo-Johnson.
+
+        Parameters
+        ----------
+        X: Pandas DataFrame of shape = [n_samples, n_features]
+            The data to be inversed.
+
+        Returns
+        -------
+        X: pandas dataframe
+            The dataframe with the inversed variables, so original values.
+        """
+        # check input dataframe and if class was fitted
+        X = self._check_transform_input_and_state(X)
+
+        for feature in self.variables_:
+            X[feature] = self._inverse_transform_series(
+                X[feature], lmbda=self.lambda_dict_[feature]
+            )
+
+        return X
+
+    def _inverse_transform_series(self, X: pd.Series, lmbda: float) -> pd.Series:
+        x_inv = pd.Series(np.zeros_like(X))
+        pos = X >= 0
+
+        # when x >= 0
+        if lmbda == 0:
+            x_inv[pos] = np.exp(X[pos]) - 1
+        else:  # lmbda != 0
+            x_inv[pos] = np.power(X[pos] * lmbda + 1, 1 / lmbda) - 1
+
+        # when x < 0
+        if lmbda != 2:
+            x_inv[~pos] = 1 - np.power(-(2 - lmbda) * X[~pos] + 1, 1 / (2 - lmbda))
+        else:  # lmbda == 2
+            x_inv[~pos] = 1 - np.exp(-X[~pos])
+
+        return x_inv

--- a/feature_engine/transformation/yeojohnson.py
+++ b/feature_engine/transformation/yeojohnson.py
@@ -7,20 +7,17 @@ import numpy as np
 import pandas as pd
 import scipy.stats as stats
 
-from feature_engine._base_transformers.base_numerical import BaseNumericalTransformer
+from feature_engine._base_transformers.base_numerical import \
+    BaseNumericalTransformer
 from feature_engine._docstrings.fit_attributes import (
-    _feature_names_in_docstring,
-    _n_features_in_docstring,
-    _variables_attribute_docstring,
-)
-from feature_engine._docstrings.init_parameters.all_trasnformers import (
-    _variables_numerical_docstring,
-)
+    _feature_names_in_docstring, _n_features_in_docstring,
+    _variables_attribute_docstring)
+from feature_engine._docstrings.init_parameters.all_trasnformers import \
+    _variables_numerical_docstring
 from feature_engine._docstrings.methods import _fit_transform_docstring
 from feature_engine._docstrings.substitute import Substitution
-from feature_engine.variable_handling._init_parameter_checks import (
-    _check_init_parameter_variables,
-)
+from feature_engine.variable_handling._init_parameter_checks import \
+    _check_init_parameter_variables
 
 
 @Substitution(
@@ -155,17 +152,17 @@ class YeoJohnsonTransformer(BaseNumericalTransformer):
 
     def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
-        Apply the inverse-transform function Yeo-Johnson.
+        Convert the data back to the original representation.
 
         Parameters
         ----------
         X: Pandas DataFrame of shape = [n_samples, n_features]
-            The data to be inversed.
+            The data to be transformed.
 
         Returns
         -------
-        X: pandas dataframe
-            The dataframe with the inversed variables, so original values.
+        X_tr: pandas dataframe
+            The dataframe with the transformed variables.
         """
         # check input dataframe and if class was fitted
         X = self._check_transform_input_and_state(X)

--- a/tests/test_transformation/test_yeojohnson_transformer.py
+++ b/tests/test_transformation/test_yeojohnson_transformer.py
@@ -1,7 +1,7 @@
+import numpy as np
 import pandas as pd
 import pytest
 from sklearn.exceptions import NotFittedError
-import numpy as np
 
 from feature_engine.transformation import YeoJohnsonTransformer
 
@@ -87,7 +87,7 @@ def test_non_fitted_error(df_vartypes):
         transformer.transform(df_vartypes)
 
 
-def test_inverse_transform_wit_columns_of_other_types(df_vartypes):
+def test_inverse_transform_automatically_select_only_transformed_columns(df_vartypes):
     X = df_vartypes.copy(deep=True)
     transformer = YeoJohnsonTransformer(variables=None)
     X_trans = transformer.fit_transform(X)
@@ -97,7 +97,7 @@ def test_inverse_transform_wit_columns_of_other_types(df_vartypes):
     pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)
 
 
-def test_inverse_with_X_negative_and_positive(df_vartypes):
+def test_inverse_with_X_negative_and_positive():
     X = pd.DataFrame(
         {
             "var1": np.arange(-20, 0),
@@ -109,6 +109,44 @@ def test_inverse_with_X_negative_and_positive(df_vartypes):
     transformer = YeoJohnsonTransformer(variables=None)
     X_trans = transformer.fit_transform(X)
 
+    X_inverse = transformer.inverse_transform(X_trans)
+
+    pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)
+
+
+def test_lambda_equals_lambda_equal_0():
+    X = pd.DataFrame(
+        {
+            "var1": np.arange(0, 20),
+            "var2": np.arange(20, 40),
+        }
+    )
+
+    transformer = YeoJohnsonTransformer(variables=None)
+    transformer = transformer.fit(X)
+
+    transformer.lambda_dict_ = {"var1": 0, "var2": 0}
+
+    X_trans = transformer.transform(X)
+    X_inverse = transformer.inverse_transform(X_trans)
+
+    pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)
+
+
+def test_lambda_equals_lambda_equal_2():
+    X = pd.DataFrame(
+        {
+            "var1": np.arange(-21, -1),
+            "var2": np.arange(-41, -21)
+        }
+    )
+
+    transformer = YeoJohnsonTransformer(variables=None)
+    transformer = transformer.fit(X)
+
+    transformer.lambda_dict_ = {"var1": 2, "var2": 2}
+
+    X_trans = transformer.transform(X)
     X_inverse = transformer.inverse_transform(X_trans)
 
     pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)

--- a/tests/test_transformation/test_yeojohnson_transformer.py
+++ b/tests/test_transformation/test_yeojohnson_transformer.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 from sklearn.exceptions import NotFittedError
+import numpy as np
 
 from feature_engine.transformation import YeoJohnsonTransformer
 
@@ -84,3 +85,25 @@ def test_non_fitted_error(df_vartypes):
     with pytest.raises(NotFittedError):
         transformer = YeoJohnsonTransformer()
         transformer.transform(df_vartypes)
+
+def test_inverse_transform_wit_columns_of_other_types(df_vartypes):
+    X = df_vartypes.copy(deep=True)
+    transformer = YeoJohnsonTransformer(variables=None)
+    X_trans = transformer.fit_transform(X)
+
+    X_inverse = transformer.inverse_transform(X_trans)
+
+    pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)
+
+def test_inverse_with_X_negative_and_positive(df_vartypes):
+
+    X = pd.DataFrame({'var1': np.arange(-20, 0),
+                      'var2': np.arange(0, 20),
+                      'var3': np.arange(-10, 10)})
+
+    transformer = YeoJohnsonTransformer(variables=None)
+    X_trans = transformer.fit_transform(X)
+
+    X_inverse = transformer.inverse_transform(X_trans)
+
+    pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)

--- a/tests/test_transformation/test_yeojohnson_transformer.py
+++ b/tests/test_transformation/test_yeojohnson_transformer.py
@@ -86,6 +86,7 @@ def test_non_fitted_error(df_vartypes):
         transformer = YeoJohnsonTransformer()
         transformer.transform(df_vartypes)
 
+
 def test_inverse_transform_wit_columns_of_other_types(df_vartypes):
     X = df_vartypes.copy(deep=True)
     transformer = YeoJohnsonTransformer(variables=None)
@@ -95,11 +96,15 @@ def test_inverse_transform_wit_columns_of_other_types(df_vartypes):
 
     pd.testing.assert_frame_equal(X, X_inverse, check_dtype=False)
 
-def test_inverse_with_X_negative_and_positive(df_vartypes):
 
-    X = pd.DataFrame({'var1': np.arange(-20, 0),
-                      'var2': np.arange(0, 20),
-                      'var3': np.arange(-10, 10)})
+def test_inverse_with_X_negative_and_positive(df_vartypes):
+    X = pd.DataFrame(
+        {
+            "var1": np.arange(-20, 0),
+            "var2": np.arange(0, 20),
+            "var3": np.arange(-10, 10),
+        }
+    )
 
     transformer = YeoJohnsonTransformer(variables=None)
     X_trans = transformer.fit_transform(X)


### PR DESCRIPTION
Add the inverse_transform function in the yeoJohnson transformer.

In sklearn PowerTransformer documentation is explained in the following way:

    The inverse of the Box-Cox transformation is given by:

```
    if lambda_ == 0:
    X = exp(X_trans)
    else:
    X = (X_trans * lambda_ + 1) ** (1 / lambda_)

    The inverse of the Yeo-Johnson transformation is given by:

    if X >= 0 and lambda_ == 0:
    X = exp(X_trans) - 1
    elif X >= 0 and lambda_ != 0:
    X = (X_trans * lambda_ + 1) ** (1 / lambda_) - 1
    elif X < 0 and lambda_ != 2:
    X = 1 - (-(2 - lambda_) * X_trans + 1) ** (1 / (2 - lambda_))
    elif X < 0 and lambda_ == 2:
    X = 1 - exp(-X_trans)
```
