### PR TITLE
Fix unbound local variable reference

### DIFF
--- a/feature_engine/variable_handling/_variable_type_checks.py
+++ b/feature_engine/variable_handling/_variable_type_checks.py
@@ -18,6 +18,9 @@ def _is_categorical_and_is_not_datetime(column: pd.Series) -> bool:
     elif is_categorical(column):
         is_cat = _is_categories_num(column) or not _is_convertible_to_dt(column)
 
+    else:
+        is_cat = False
+
     return is_cat
 
 


### PR DESCRIPTION
This fixes an error when transformers are passed variables that do not fall under the checks performed in this function. Not sure if it's the right approach though.