### PR TITLE
Add missing_only init param to all imputers. missing_only is used in combination w/ the variables param.

### DIFF
--- a/feature_engine/_docstrings/init_parameters/imputers.py
+++ b/feature_engine/_docstrings/init_parameters/imputers.py
@@ -1,0 +1,6 @@
+_missing_only_docstring = """missing_only: bool, default=False
+        If `missing_only` equals `True` and `variables` equals `None` then the transformer 
+        will only select the numerical variables that show missing values during `fit()`. 
+        All categorical variables, even those with no missing values, will be returned even 
+        when `missing_only` equals `True`.
+"""

--- a/feature_engine/imputation/arbitrary_number.py
+++ b/feature_engine/imputation/arbitrary_number.py
@@ -8,6 +8,7 @@ import pandas as pd
 from feature_engine._check_input_parameters.check_input_dictionary import (
     _check_numerical_dict,
 )
+
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _imputer_dict_docstring,

--- a/feature_engine/imputation/base_imputer.py
+++ b/feature_engine/imputation/base_imputer.py
@@ -9,6 +9,16 @@ from feature_engine.tags import _return_tags
 
 class BaseImputer(BaseEstimator, TransformerMixin, GetFeatureNamesOutMixin):
     """shared set-up checks and methods across imputers"""
+    def __init__(
+            self,
+            missing_only: bool = False,
+    ):
+        if not isinstance(missing_only, bool):
+            raise ValueError(
+                f"missing_only must be a boolean type. Got {missing_only} instead."
+            )
+
+        self.missing_only = missing_only
 
     def _transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """


### PR DESCRIPTION
Closes #388.

When `missing_only=True` and `variables=None`, all numerical variables that do **not** contain missing values will be omitted from `self.variables_`.

This functionality does not apply to categorical variables.