### PR TITLE
refactor: exposing the unseen var of the categorical encoder

### DIFF
--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -347,7 +347,7 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
         if self.unseen == "encode":
             X = X.mask(mask_unseen, other=self.fill_value)
         if self.unseen == "ignore":
-            X = X.mask(mask_unseen, other=None)
+            X = X.mask(mask_unseen, other=np.nan)
 
         return X
 

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -331,7 +331,15 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
         if self.unseen != "raise":
             # replace unseen with a seen value - later it will be replaced
-            mask_unseen = ~X.apply(lambda x: x.isin(self._categories[x.name]))
+            mask_unseen = ~X.apply(
+                lambda x: x.isin(
+                    self._categories[x.name]
+                    )
+                if x.name in list(
+                        self._categories.keys()
+                        )
+                else True
+                )
             for col, values in self._categories.items():
                 X.loc[mask_unseen[col], [col]] = values[0]
 

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -224,8 +224,6 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
 
     ) -> None:
         check_parameter_unseen(unseen, ["ignore", "raise", "encode"])
-
-        check_parameter_unseen(unseen, ["ignore", "raise", "encode"])
         super().__init__(variables, ignore_format)
         self.encoding_method = encoding_method
         self.cv = cv

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -346,7 +346,7 @@ class DecisionTreeEncoder(CategoricalInitMixin, CategoricalMethodsMixin):
         X = self.encoder_.transform(X)
         if self.unseen == "encode":
             X = X.mask(mask_unseen, other=self.fill_value)
-        elif self.unseen == "ignore":
+        if self.unseen == "ignore":
             X = X.mask(mask_unseen, other=None)
 
         return X

--- a/tests/test_encoding/test_decision_tree_encoder.py
+++ b/tests/test_encoding/test_decision_tree_encoder.py
@@ -195,7 +195,12 @@ def test_unseen_param(df_enc):
     encoder.fit(df_enc, df_enc["target"])
     assert encoder.encoder_[0].unseen == "ignore"
 
-    # ignore unseen
+    # ignore
+    encoder = DecisionTreeEncoder(unseen="ignore", regression=False)
+    encoder.fit(df_enc, df_enc["target"])
+    assert encoder.encoder_[0].unseen == "ignore"
+
+    # raise unseen
     encoder = DecisionTreeEncoder(unseen="raise", regression=False)
     encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
     assert encoder.encoder_[0].unseen == "raise"

--- a/tests/test_encoding/test_decision_tree_encoder.py
+++ b/tests/test_encoding/test_decision_tree_encoder.py
@@ -206,30 +206,6 @@ def test_fill_value_error(df_enc):
         encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
 
 
-def test_fit_no_errors_if_new_cat_values_and_unseen_is_encode_param(df_enc):
-
-    encoder = DecisionTreeEncoder(
-        unseen="encode",
-        regression=False,
-        fill_value=-1
-    )
-
-    encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
-    X_unseen_values_1 = pd.DataFrame({
-        "var_A": ['ZZZ', 'YYY'],
-        "var_B": ['YYY', 'ZZZ'],
-    })
-    X_unseen_values_2 = pd.DataFrame({
-        "var_A": ['XXX', -1],
-        "var_B": ['WWW', -1],
-    })
-
-    transf_unseen_1 = encoder.transform(X_unseen_values_1)
-    transf_unseen_2 = encoder.transform(X_unseen_values_2)
-    # unseen categories must be encoded in the same way
-    pd.testing.assert_frame_equal(transf_unseen_1, transf_unseen_2)
-
-
 def test_fit_errors_if_new_cat_values_and_unseen_is_raise_param(df_enc):
     encoder = DecisionTreeEncoder(
         unseen='raise',
@@ -279,7 +255,6 @@ def test_unseen_for_regression_and_numeric_categories(df_enc_numeric):
     assert (X.iloc[row_index_fill_value]).equals(X.iloc[row_index_unseen_value])
 
 
-
 def test_fit_no_errors_if_new_cat_values_and_unseen_is_encode_param(df_enc):
 
     encoder = DecisionTreeEncoder(
@@ -302,18 +277,3 @@ def test_fit_no_errors_if_new_cat_values_and_unseen_is_encode_param(df_enc):
     transf_unseen_2 = encoder.transform(X_unseen_values_2)
     # unseen categories must be encoded in the same way
     pd.testing.assert_frame_equal(transf_unseen_1, transf_unseen_2)
-
-
-def test_fit_errors_if_new_cat_values_and_unseen_is_raise_param(df_enc):
-    encoder = DecisionTreeEncoder(
-        unseen='raise',
-        regression=False
-    )
-    encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
-    X_unseen_values = pd.DataFrame({
-        "var_A": ['ZZZ', 'YYY'],
-        "var_B": ['YYY', 'ZZZ'],
-    })
-    # new categories will raise an error
-    with pytest.raises(ValueError):
-        encoder.transform(X_unseen_values)

--- a/tests/test_encoding/test_decision_tree_encoder.py
+++ b/tests/test_encoding/test_decision_tree_encoder.py
@@ -221,6 +221,21 @@ def test_fit_errors_if_new_cat_values_and_unseen_is_raise_param(df_enc):
         encoder.transform(X_unseen_values)
 
 
+def test_fit_errors_if_new_cat_values_and_unseen_is_ignore_param(df_enc):
+    encoder = DecisionTreeEncoder(
+        unseen='ignore',
+        regression=False
+    )
+    encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
+    X_unseen_values = pd.DataFrame({
+        "var_A": ['ZZZ', 'YYY'],
+        "var_B": ['YYY', 'ZZZ'],
+    })
+    # new categories will raise an error
+    with pytest.raises(ValueError):
+        encoder.transform(X_unseen_values)
+
+
 def test_unseen_for_regression_and_numeric_categories(df_enc_numeric):
     random = np.random.RandomState(42)
     y = random.normal(0, 0.1, len(df_enc_numeric))

--- a/tests/test_encoding/test_decision_tree_encoder.py
+++ b/tests/test_encoding/test_decision_tree_encoder.py
@@ -237,7 +237,7 @@ def test_error_fill_value_param(df_enc):
 
 def test_fit_errors_if_new_cat_values_and_unseen_is_raise_param(df_enc):
     encoder = DecisionTreeEncoder(
-        unseen='raise',
+        unseen="raise",
         regression=False
     )
     encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
@@ -252,7 +252,7 @@ def test_fit_errors_if_new_cat_values_and_unseen_is_raise_param(df_enc):
 
 def test_if_new_cat_values_and_unseen_is_ignore_param(df_enc):
     encoder = DecisionTreeEncoder(
-        unseen='ignore',
+        unseen="ignore",
         regression=False
     )
     encoder.fit(df_enc[["var_A", "var_B"]], df_enc["target"])
@@ -262,7 +262,7 @@ def test_if_new_cat_values_and_unseen_is_ignore_param(df_enc):
     })
 
     unseen_transformed = encoder.transform(X_unseen_values)
-    none_unseen = pd.DataFrame(None, columns=X_unseen_values.columns,
+    none_unseen = pd.DataFrame(np.nan, columns=X_unseen_values.columns,
                                index=X_unseen_values.index)
     pd.testing.assert_frame_equal(unseen_transformed, none_unseen, check_dtype=False)
 


### PR DESCRIPTION
closes #728
closes #588 

Exposing the `unseen` parameter for the `DecisionTreeEncoder`.
Changing the encoder_ pipeline for an encoding_dict_ that maps from categories to numerical mappings (the predictions of the tree)