### PR TITLE
Fix pandas qcut link for the EqualFrequencyDiscretiser user guide

### DIFF
--- a/docs/user_guide/discretisation/EqualFrequencyDiscretiser.rst
+++ b/docs/user_guide/discretisation/EqualFrequencyDiscretiser.rst
@@ -374,7 +374,7 @@ For alternative binning techniques, check out the following resources:
 
 Check out also:
 
-- `Pandas cut <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.cut.html>`_.
+- `Pandas qcut <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.qcut.html>`_.
 
 
 Additional resources


### PR DESCRIPTION
The current text (Pandas cut) links to the Pandas cut library. I am just replacing cut with qcut since that's what EqualFrequencyDiscretiser uses under the hood.