### PR TITLE
Math features migrate to numpy

### DIFF
--- a/feature_engine/creation/__init__.py
+++ b/feature_engine/creation/__init__.py
@@ -2,6 +2,8 @@
 The module creation includes classes to create new variables by combination of existing
 variables in the dataframe.
 """
+
+from .custom_functions import CustomFunctions
 from .cyclical_features import CyclicalFeatures
 from .decision_tree_features import DecisionTreeFeatures
 from .math_features import MathFeatures
@@ -12,4 +14,5 @@ __all__ = [
     "MathFeatures",
     "RelativeFeatures",
     "CyclicalFeatures",
+    "CustomFunctions",
 ]

--- a/feature_engine/creation/custom_functions.py
+++ b/feature_engine/creation/custom_functions.py
@@ -6,6 +6,5 @@ custom function should be processed via pandas.agg() or numpy.apply_over_axes()
 
 class CustomFunctions:
 
-
     def __init__(self, scope_target):
         self.scope_target = scope_target

--- a/feature_engine/creation/custom_functions.py
+++ b/feature_engine/creation/custom_functions.py
@@ -1,0 +1,11 @@
+"""
+CustomFunctions is a wrapper, which allows MathFunctions to detect if a
+custom function should be processed via pandas.agg() or numpy.apply_over_axes()
+"""
+
+
+class CustomFunctions:
+
+
+    def __init__(self, scope_target):
+        self.scope_target = scope_target

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -378,7 +378,5 @@ class MathFeatures(BaseCreation):
                 feature_names = [
                     f"{function}_{'_'.join(varlist)}" for function in functions
                 ]
-            else:
-                feature_names = [f"{self.func}_{'_'.join(varlist)}"]
 
         return feature_names

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -343,8 +343,6 @@ class MathFeatures(BaseCreation):
                         result = np_df[np_variables].agg(np_function, axis=1)
                         np_result_df[new_variable_names[np_function_idx]] = result
 
-                    print(scope_target)
-
             return np_result_df
 
         X = self._check_transform_input_and_state(X)

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional, Union
 
+import numpy as np
 import pandas as pd
-
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -130,6 +130,58 @@ class MathFeatures(BaseCreation):
     0   1   4         2.5
     1   2   5         3.5
     2   3   6         4.5
+
+    Examples for Custom Functions
+    -----------------------------
+    We do not recommend using a custum function in combination with
+    the pandas.agg(). Due to performance issues it should be avoided.
+    For the sake of completeness a short example:
+
+    >>> import pandas as pd
+    >>> from feature_engine.creation import MathFeatures
+    >>>
+    >>> def customfunction_agg(series):
+    >>>    # pandas.agg calls the custom-function twice
+    >>>    # first with a non series type
+    >>>    # second with a series type -> we need the series type
+    >>>    if not isinstance(series, pd.Series):
+    >>>        raise ValueError("Only Series allowed")
+    >>>    result = series["Age"] + series["Marks"]
+    >>>    return result
+
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3], x2 = [4,5,6]))
+    >>> mf = MathFeatures(variables = ["x1","x2"], func = "customfunction_agg")
+    >>> mf.fit(X)
+    >>> X = mf.transform(X))
+       x1  x2  customfunction_agg_x1_x2
+    0   1   4         5
+    1   2   5         7
+    2   3   6         9
+
+    We recommend the usage of custom functions via the numpy.apply_over_axes().
+    A custom function gets processed via numpy.apply_over_axes() when we extend
+    a provided wrapper class.
+
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from feature_engine.creation import MathFeatures
+    >>> from feature_engine.creation.custom_functions import CustomFunctions
+    >>> class custom_function_1(CustomFunctions):
+    >>>    def domain_specific_custom_function_1(self, df, a):
+    >>>       result = np.sum(df, axis=1)
+    >>>       return result
+    >>> cufu = custom_function_1(scope_target="numpy")
+    >>> X = pd.DataFrame(dict(x1 = [1,2,3], x2 = [4,5,6]))
+    >>> mf = MathFeatures(variables = ["x1","x2"], func = [cufu.domain_specific_custom_function_1])
+    >>> mf.fit(X)
+    >>> X = mf.transform(X)
+
+        x1  x2        domain_specific_custom_function_1_x1_x2
+    0   1   4         5
+    1   2   5         7
+    2   3   6         9
+
+
     """
 
     def __init__(
@@ -140,6 +192,16 @@ class MathFeatures(BaseCreation):
         missing_values: str = "raise",
         drop_original: bool = False,
     ) -> None:
+
+        # casting input parameter func to a list
+        function_input = []
+        if isinstance(func, str):
+            function_input.append(func)
+        elif isinstance(func, list):
+            function_input = func
+        else:
+            function_input = func
+        func = function_input
 
         if (
             not isinstance(variables, list)
@@ -202,14 +264,109 @@ class MathFeatures(BaseCreation):
         X_new: Pandas dataframe, shape = [n_samples, n_features + n_operations]
             The input dataframe plus the new variables.
         """
+
+        def np_transform(np_df, new_variable_names, np_variables, np_functions):
+            #    calculations = ('mean','sum', 'min', 'max', 'prod', 'median', 'std', 'var')
+            np_result_df = df = pd.DataFrame()
+            for np_function_idx, np_function in enumerate(np_functions):
+                if np_function in ("sum", "np.sum"):
+                    result = np.nansum(
+                        np_df[np_variables],
+                        axis=1,
+                    )
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+                    pass
+
+                elif np_function in  ("mean", "np.mean"):
+                    result = np.nanmean(
+                        np_df[np_variables],
+                        axis=1,
+                    )
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                elif np_function in ("min", "np.min"):
+                    result = np.nanmin(
+                        np_df[np_variables],
+                        axis=1,
+                    )
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                elif np_function in ("max", "np.max"):
+                    result = np.nanmax(
+                        np_df[np_variables],
+                        axis=1,
+                    )
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                elif np_function in ("prod", "np.prod"):
+                    result = np.nanprod(
+                        np_df[np_variables],
+                        axis=1,
+                    )
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                elif np_function in ("median", "np.median"):
+                    result = np.nanmedian(
+                        np_df[np_variables],
+                        axis=1,
+                    )
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                elif np_function in ("std", "np.std"):
+                    result = np.nanstd(np_df[np_variables], axis=1, ddof=1)
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                elif np_function in ("var", "np.var"):
+                    result = np.nanvar(np_df[np_variables], axis=1, ddof=1)
+                    np_result_df[new_variable_names[np_function_idx]] = pd.Series(
+                        result
+                    )
+
+                else:
+                    try:
+                        scope_target = np_function.__self__.scope_target
+                    except:
+                        scope_target = "pandas"
+
+                    if scope_target == "numpy":
+                        result = np.apply_over_axes(np_function, np_df[np_variables], 1)
+                        np_result_df[new_variable_names[np_function_idx]] = (
+                            pd.DataFrame(
+                                data=result,
+                                columns=[new_variable_names[np_function_idx]],
+                            )
+                        )
+                    elif scope_target == "pandas":
+                        result = np_df[np_variables].agg(np_function, axis=1)
+                        np_result_df[new_variable_names[np_function_idx]] = result
+
+                    print(scope_target)
+
+            return np_result_df
+
         X = self._check_transform_input_and_state(X)
 
         new_variable_names = self._get_new_features_name()
 
-        if len(new_variable_names) == 1:
-            X[new_variable_names[0]] = X[self.variables].agg(self.func, axis=1)
-        else:
-            X[new_variable_names] = X[self.variables].agg(self.func, axis=1)
+
+        X = pd.concat(
+            [X, np_transform(X, new_variable_names, self.variables, self.func)],
+            axis=1,
+        )
 
         if self.drop_original:
             X.drop(columns=self.variables, inplace=True)

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -259,14 +259,12 @@ class MathFeatures(BaseCreation):
         def np_transform(np_df, new_variable_names, np_variables, np_functions):
             np_result_df = pd.DataFrame()
             for np_function_idx, np_function in enumerate(np_functions):
-                np_function_name = ""
                 if callable(np_function):
                     np_function_name = np_function.__name__
                 else:
                     np_function_name = np_function
 
                 if np_function_name in ("sum"):
-
                     result = np.nansum(
                         np_df[np_variables],
                         axis=1,
@@ -274,10 +272,9 @@ class MathFeatures(BaseCreation):
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
-                    pass
+                    continue
 
                 elif np_function_name in ("mean"):
-
                     result = np.nanmean(
                         np_df[np_variables],
                         axis=1,
@@ -285,9 +282,9 @@ class MathFeatures(BaseCreation):
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 elif np_function_name in ("min",):
-
                     result = np.nanmin(
                         np_df[np_variables],
                         axis=1,
@@ -295,6 +292,7 @@ class MathFeatures(BaseCreation):
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 elif np_function_name in ("max",):
                     result = np.nanmax(
@@ -304,9 +302,9 @@ class MathFeatures(BaseCreation):
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 elif np_function_name in ("prod"):
-
                     result = np.nanprod(
                         np_df[np_variables],
                         axis=1,
@@ -314,9 +312,9 @@ class MathFeatures(BaseCreation):
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 elif np_function_name in ("median"):
-
                     result = np.nanmedian(
                         np_df[np_variables],
                         axis=1,
@@ -324,20 +322,21 @@ class MathFeatures(BaseCreation):
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 elif np_function_name in ("std"):
-
                     result = np.nanstd(np_df[np_variables], axis=1, ddof=1)
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 elif np_function_name in ("var"):
-
                     result = np.nanvar(np_df[np_variables], axis=1, ddof=1)
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
+                    continue
 
                 else:
                     try:

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -369,11 +369,10 @@ class MathFeatures(BaseCreation):
         else:
             varlist = [f"{var}" for var in self.variables_]
 
-            if isinstance(self.func, list):
-                functions = [
+            functions = [
                     fun if type(fun) is str else fun.__name__ for fun in self.func
                 ]
-                feature_names = [
+            feature_names = [
                     f"{function}_{'_'.join(varlist)}" for function in functions
                 ]
 

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -233,12 +233,6 @@ class MathFeatures(BaseCreation):
                         "The number of new feature names must coincide with the number "
                         "of functions."
                     )
-            else:
-                if len(new_variables_names) != 1:
-                    raise ValueError(
-                        "The number of new feature names must coincide with the number "
-                        "of functions."
-                    )
 
         super().__init__(missing_values, drop_original)
 

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -227,12 +227,11 @@ class MathFeatures(BaseCreation):
                 )
 
         if new_variables_names is not None:
-            if isinstance(func, list):
-                if len(new_variables_names) != len(func):
-                    raise ValueError(
-                        "The number of new feature names must coincide with the number "
-                        "of functions."
-                    )
+            if len(new_variables_names) != len(func):
+                raise ValueError(
+                    "The number of new feature names must coincide with the number "
+                    "of functions."
+                )
 
         super().__init__(missing_values, drop_original)
 

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -227,11 +228,12 @@ class MathFeatures(BaseCreation):
                 )
 
         if new_variables_names is not None:
-            if len(new_variables_names) != len(func):
-                raise ValueError(
-                    "The number of new feature names must coincide with the number "
-                    "of functions."
-                )
+            if isinstance(func, list):
+                if len(new_variables_names) != len(func):
+                    raise ValueError(
+                        "The number of new feature names must coincide with the number "
+                        "of functions."
+                    )
 
         super().__init__(missing_values, drop_original)
 
@@ -257,7 +259,14 @@ class MathFeatures(BaseCreation):
         def np_transform(np_df, new_variable_names, np_variables, np_functions):
             np_result_df = pd.DataFrame()
             for np_function_idx, np_function in enumerate(np_functions):
-                if np_function in ("sum", "np.sum"):
+                np_function_name = ""
+                if callable(np_function):
+                    np_function_name = np_function.__name__
+                else:
+                    np_function_name = np_function
+
+                if np_function_name in ("sum"):
+
                     result = np.nansum(
                         np_df[np_variables],
                         axis=1,
@@ -267,7 +276,8 @@ class MathFeatures(BaseCreation):
                     )
                     pass
 
-                elif np_function in ("mean", "np.mean"):
+                elif np_function_name in ("mean"):
+
                     result = np.nanmean(
                         np_df[np_variables],
                         axis=1,
@@ -276,7 +286,8 @@ class MathFeatures(BaseCreation):
                         result
                     )
 
-                elif np_function in ("min", "np.min"):
+                elif np_function_name in ("min",):
+
                     result = np.nanmin(
                         np_df[np_variables],
                         axis=1,
@@ -285,7 +296,7 @@ class MathFeatures(BaseCreation):
                         result
                     )
 
-                elif np_function in ("max", "np.max"):
+                elif np_function_name in ("max",):
                     result = np.nanmax(
                         np_df[np_variables],
                         axis=1,
@@ -294,7 +305,8 @@ class MathFeatures(BaseCreation):
                         result
                     )
 
-                elif np_function in ("prod", "np.prod"):
+                elif np_function_name in ("prod"):
+
                     result = np.nanprod(
                         np_df[np_variables],
                         axis=1,
@@ -303,7 +315,8 @@ class MathFeatures(BaseCreation):
                         result
                     )
 
-                elif np_function in ("median", "np.median"):
+                elif np_function_name in ("median"):
+
                     result = np.nanmedian(
                         np_df[np_variables],
                         axis=1,
@@ -312,13 +325,15 @@ class MathFeatures(BaseCreation):
                         result
                     )
 
-                elif np_function in ("std", "np.std"):
+                elif np_function_name in ("std"):
+
                     result = np.nanstd(np_df[np_variables], axis=1, ddof=1)
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
 
-                elif np_function in ("var", "np.var"):
+                elif np_function_name in ("var"):
+
                     result = np.nanvar(np_df[np_variables], axis=1, ddof=1)
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
@@ -339,6 +354,7 @@ class MathFeatures(BaseCreation):
                             )
                         )
                     elif scope_target == "pandas":
+                        foo = np_function.__name__
                         result = np_df[np_variables].agg(np_function, axis=1)
                         np_result_df[new_variable_names[np_function_idx]] = result
 
@@ -368,11 +384,9 @@ class MathFeatures(BaseCreation):
         else:
             varlist = [f"{var}" for var in self.variables_]
 
-            functions = [
-                    fun if type(fun) is str else fun.__name__ for fun in self.func
-                ]
+            functions = [fun if type(fun) is str else fun.__name__ for fun in self.func]
             feature_names = [
-                    f"{function}_{'_'.join(varlist)}" for function in functions
-                ]
+                f"{function}_{'_'.join(varlist)}" for function in functions
+            ]
 
         return feature_names

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -131,8 +131,6 @@ class MathFeatures(BaseCreation):
     1   2   5         3.5
     2   3   6         4.5
 
-    Examples for Custom Functions
-    -----------------------------
     We do not recommend using a custum function in combination with
     the pandas.agg(). Due to performance issues it should be avoided.
     For the sake of completeness a short example:
@@ -172,16 +170,14 @@ class MathFeatures(BaseCreation):
     >>>       return result
     >>> cufu = custom_function_1(scope_target="numpy")
     >>> X = pd.DataFrame(dict(x1 = [1,2,3], x2 = [4,5,6]))
-    >>> mf = MathFeatures(variables = ["x1","x2"], func = [cufu.domain_specific_custom_function_1])
+    >>> mf = MathFeatures(variables = ["x1","x2"],
+    >>>                   func = [cufu.domain_specific_custom_function_1])
     >>> mf.fit(X)
     >>> X = mf.transform(X)
-
         x1  x2        domain_specific_custom_function_1_x1_x2
     0   1   4         5
     1   2   5         7
     2   3   6         9
-
-
     """
 
     def __init__(
@@ -266,8 +262,7 @@ class MathFeatures(BaseCreation):
         """
 
         def np_transform(np_df, new_variable_names, np_variables, np_functions):
-            #    calculations = ('mean','sum', 'min', 'max', 'prod', 'median', 'std', 'var')
-            np_result_df = df = pd.DataFrame()
+            np_result_df = pd.DataFrame()
             for np_function_idx, np_function in enumerate(np_functions):
                 if np_function in ("sum", "np.sum"):
                     result = np.nansum(
@@ -279,7 +274,7 @@ class MathFeatures(BaseCreation):
                     )
                     pass
 
-                elif np_function in  ("mean", "np.mean"):
+                elif np_function in ("mean", "np.mean"):
                     result = np.nanmean(
                         np_df[np_variables],
                         axis=1,
@@ -339,7 +334,7 @@ class MathFeatures(BaseCreation):
                 else:
                     try:
                         scope_target = np_function.__self__.scope_target
-                    except:
+                    except Exception:
                         scope_target = "pandas"
 
                     if scope_target == "numpy":
@@ -361,7 +356,6 @@ class MathFeatures(BaseCreation):
         X = self._check_transform_input_and_state(X)
 
         new_variable_names = self._get_new_features_name()
-
 
         X = pd.concat(
             [X, np_transform(X, new_variable_names, self.variables, self.func)],

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -194,7 +194,6 @@ class MathFeatures(BaseCreation):
         missing_values: str = "raise",
         drop_original: bool = False,
         ddof: Union[int, float] = 1,
-
     ) -> None:
 
         # casting input parameter func to a list
@@ -242,10 +241,8 @@ class MathFeatures(BaseCreation):
                         "of functions."
                     )
 
-        if not isinstance(ddof, int) and not isinstance(ddof, float):
-            raise ValueError(
-                "The type of ddof has to be Integer or Float"
-            )
+        if not (isinstance(ddof, int) or isinstance(ddof, float)):
+            raise ValueError("The type of ddof has to be Integer or Float")
 
         super().__init__(missing_values, drop_original)
 

--- a/feature_engine/creation/math_features.py
+++ b/feature_engine/creation/math_features.py
@@ -69,6 +69,11 @@ class MathFeatures(BaseCreation):
         one name per function. If None, the transformer will assign arbitrary names,
         starting with the function and followed by the variables separated by _.
 
+    ddof: int, float, default = 1
+        Means Delta Degrees of Freedom. The divisor used in calculations is
+        N - ddof, where N represents the number of elements.
+        By default ddof is 1.
+
     {missing_values}
 
     {drop_original}
@@ -188,6 +193,8 @@ class MathFeatures(BaseCreation):
         new_variables_names: Optional[List[str]] = None,
         missing_values: str = "raise",
         drop_original: bool = False,
+        ddof: Union[int, float] = 1,
+
     ) -> None:
 
         # casting input parameter func to a list
@@ -235,11 +242,17 @@ class MathFeatures(BaseCreation):
                         "of functions."
                     )
 
+        if not isinstance(ddof, int) and not isinstance(ddof, float):
+            raise ValueError(
+                "The type of ddof has to be Integer or Float"
+            )
+
         super().__init__(missing_values, drop_original)
 
         self.variables = variables
         self.func = func
         self.new_variables_names = new_variables_names
+        self.ddof = ddof
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
@@ -325,14 +338,14 @@ class MathFeatures(BaseCreation):
                     continue
 
                 elif np_function_name in ("std"):
-                    result = np.nanstd(np_df[np_variables], axis=1, ddof=1)
+                    result = np.nanstd(np_df[np_variables], axis=1, ddof=self.ddof)
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
                     continue
 
                 elif np_function_name in ("var"):
-                    result = np.nanvar(np_df[np_variables], axis=1, ddof=1)
+                    result = np.nanvar(np_df[np_variables], axis=1, ddof=self.ddof)
                     np_result_df[new_variable_names[np_function_idx]] = pd.Series(
                         result
                     )
@@ -353,7 +366,6 @@ class MathFeatures(BaseCreation):
                             )
                         )
                     elif scope_target == "pandas":
-                        foo = np_function.__name__
                         result = np_df[np_variables].agg(np_function, axis=1)
                         np_result_df[new_variable_names[np_function_idx]] = result
 

--- a/tests/test_creation/test_math_features.py
+++ b/tests/test_creation/test_math_features.py
@@ -82,7 +82,8 @@ def test_error_new_variable_names_not_permitted():
 
 def test_aggregations_with_strings(df_vartypes):
     transformer = MathFeatures(
-        variables=["Age", "Marks"], func=["sum", "prod", "mean", "std", "max", "min", "median"]
+        variables=["Age", "Marks"],
+        func=["sum", "prod", "mean", "std", "max", "min", "median", "var"],
     )
     X = transformer.fit_transform(df_vartypes)
 
@@ -104,6 +105,8 @@ def test_aggregations_with_strings(df_vartypes):
             ],
             "max_Age_Marks": [20.0, 21.0, 19.0, 18.0],
             "min_Age_Marks": [0.9, 0.8, 0.7, 0.6],
+            "median_Age_Marks": [10.45, 10.90, 9.85, 9.30],
+            "var_Age_Marks": [182.405, 204.020, 167.445, 151.380],
         }
     )
 

--- a/tests/test_creation/test_math_features.py
+++ b/tests/test_creation/test_math_features.py
@@ -40,6 +40,11 @@ def test_error_if_func_is_dictionary():
         MathFeatures(variables=["Age", "Name"], func={"A": "sum", "B": "mean"})
 
 
+def test_error_if_ddof_is_not_int_or_float():
+    with pytest.raises(ValueError):
+        MathFeatures(variables=["Age", "Name"], func={"std", "var"}, ddof="A")
+
+
 @pytest.mark.parametrize("_variables", [[4], ("vara", "vara"), "vara"])
 def test_error_if_new_variable_names_not_permitted(_variables):
     with pytest.raises(ValueError):
@@ -497,5 +502,67 @@ def test_customfunction_numpy_three_functions(df_vartypes):
             "domain_specific_custom_function_2_Age_Marks": [20.9, 21.8, 19.7, 18.6],
         }
     )
+    # transform params
+    pd.testing.assert_frame_equal(X, ref)
+
+
+def test_ddof_equal_0(df_vartypes):
+    transformer = MathFeatures(variables=["Age", "Marks"], func=["std", "var"], ddof=0)
+    X = transformer.fit_transform(df_vartypes)
+
+    ref = pd.DataFrame.from_dict(
+        {
+            "Name": ["tom", "nick", "krish", "jack"],
+            "City": ["London", "Manchester", "Liverpool", "Bristol"],
+            "Age": [20, 21, 19, 18],
+            "Marks": [0.9, 0.8, 0.7, 0.6],
+            "dob": dob_datrange,
+            "std_Age_Marks": [
+                9.55000,
+                10.10000,
+                9.15000,
+                8.70000,
+            ],
+            "var_Age_Marks": [
+                91.20250,
+                102.01000,
+                83.72250,
+                75.69000,
+            ],
+        }
+    )
+
+    # transform params
+    pd.testing.assert_frame_equal(X, ref)
+
+
+def test_ddof_equal_float(df_vartypes):
+    transformer = MathFeatures(
+        variables=["Age", "Marks"], func=["std", "var"], ddof=1.5
+    )
+    X = transformer.fit_transform(df_vartypes)
+
+    ref = pd.DataFrame.from_dict(
+        {
+            "Name": ["tom", "nick", "krish", "jack"],
+            "City": ["London", "Manchester", "Liverpool", "Bristol"],
+            "Age": [20, 21, 19, 18],
+            "Marks": [0.9, 0.8, 0.7, 0.6],
+            "dob": dob_datrange,
+            "std_Age_Marks": [
+                19.10000,
+                20.20000,
+                18.30000,
+                17.40000,
+            ],
+            "var_Age_Marks": [
+                364.81000,
+                408.04000,
+                334.89000,
+                302.76000,
+            ],
+        }
+    )
+
     # transform params
     pd.testing.assert_frame_equal(X, ref)

--- a/tests/test_creation/test_math_features.py
+++ b/tests/test_creation/test_math_features.py
@@ -438,7 +438,7 @@ def test_customfunction_numpy(df_vartypes):
 
     cufu = custom_function_1(scope_target="numpy")
 
-    #test only one customfunction
+    # test only one customfunction
     transformer = MathFeatures(
         variables=["Age", "Marks"],
         func=[cufu.domain_specific_custom_function_1],
@@ -459,6 +459,7 @@ def test_customfunction_numpy(df_vartypes):
     # transform params
     pd.testing.assert_frame_equal(X, ref)
 
+
 def test_customfunction_numpy_three_functions(df_vartypes):
     class custom_function_1(CustomFunctions):
         def domain_specific_custom_function_1(self, df, a):
@@ -471,10 +472,14 @@ def test_customfunction_numpy_three_functions(df_vartypes):
 
     cufu = custom_function_1(scope_target="numpy")
 
-    #test only one customfunction
+    # test only one customfunction
     transformer = MathFeatures(
         variables=["Age", "Marks"],
-        func=["sum", cufu.domain_specific_custom_function_1, cufu.domain_specific_custom_function_2],
+        func=[
+            "sum",
+            cufu.domain_specific_custom_function_1,
+            cufu.domain_specific_custom_function_2,
+        ],
     )
 
     X = transformer.fit_transform(df_vartypes)
@@ -489,9 +494,7 @@ def test_customfunction_numpy_three_functions(df_vartypes):
             "sum_Age_Marks": [20.9, 21.8, 19.7, 18.6],
             "domain_specific_custom_function_1_Age_Marks": [20.9, 21.8, 19.7, 18.6],
             "domain_specific_custom_function_2_Age_Marks": [20.9, 21.8, 19.7, 18.6],
-
         }
     )
     # transform params
     pd.testing.assert_frame_equal(X, ref)
-

--- a/tests/test_creation/test_math_features.py
+++ b/tests/test_creation/test_math_features.py
@@ -354,6 +354,7 @@ def test_get_feature_names_out_raises_error_when_wrong_param(
     with pytest.raises(ValueError):
         transformer.get_feature_names_out(input_features=_input_features)
 
+
 def test_customfunction_agg_with_not_nan_save(df_vartypes):
 
     df_na = df_vartypes.copy()

--- a/tests/test_creation/test_math_features.py
+++ b/tests/test_creation/test_math_features.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.pipeline import Pipeline
+
 from feature_engine.creation import MathFeatures
 from feature_engine.creation.custom_functions import CustomFunctions
-from sklearn.pipeline import Pipeline
 
 dob_datrange = pd.date_range("2020-02-24", periods=4, freq="min")
 

--- a/tests/test_creation/test_math_features.py
+++ b/tests/test_creation/test_math_features.py
@@ -82,7 +82,7 @@ def test_error_new_variable_names_not_permitted():
 
 def test_aggregations_with_strings(df_vartypes):
     transformer = MathFeatures(
-        variables=["Age", "Marks"], func=["sum", "prod", "mean", "std", "max", "min"]
+        variables=["Age", "Marks"], func=["sum", "prod", "mean", "std", "max", "min", "median"]
     )
     X = transformer.fit_transform(df_vartypes)
 


### PR DESCRIPTION
I migrated the transform method in math_features from pandas.agg to native numpy functions with backward compatibility. At least all existing tests on math-feature pass.

Following key-functions are implemented:

- "sum", "np.sum"
- "mean", "np.mean"
- "min", "np.min"
- "max", "np.max"
- "prod", "np.prod"
- "median", "np.median"
- "std", "np.std"
- "var", "np.var"

In case a defined function is not in above collection it falls back to pandas.agg. In the Examples-section I described the way to call a custom function with numpy.apply_over_axes()

I additionally changed the deprecated 

`dob_datrange = pd.date_range("2020-02-24", periods=4, freq="T")`

to

`dob_datrange = pd.date_range("2020-02-24", periods=4, freq="min")`

to avoid FutureWarnings from pandas.


Please have a look. @solegalli 