### PR TITLE
fix information value selector tests

### DIFF
--- a/feature_engine/selection/information_value.py
+++ b/feature_engine/selection/information_value.py
@@ -277,3 +277,7 @@ class SelectByInformationValue(BaseSelector, WoE):
         # are not suitable
         tags_dict["_skip_test"] = True
         return tags_dict
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        return tags

--- a/tests/test_selection/test_check_estimator_selectors.py
+++ b/tests/test_selection/test_check_estimator_selectors.py
@@ -93,7 +93,10 @@ else:
     # TODO: investigate checks for target mean selector.
     @pytest.mark.parametrize("estimator", _estimators)
     def test_check_estimator_from_sklearn(estimator):
-        if estimator.__class__.__name__ != "SelectByTargetMeanPerformance":
+        if estimator.__class__.__name__ not in [
+            "SelectByTargetMeanPerformance",
+            "SelectByInformationValue",
+        ]:
             failed_tests = estimator._more_tags()["_xfail_checks"]
             return check_estimator(
                 estimator=estimator, expected_failed_checks=failed_tests


### PR DESCRIPTION
Added the sklearn tags attribute as required by sklearn version 1.7.0

The tests now fail, because this transformer requires the target to be binary. However, to enforce this, it needs to inherit from ClassifierMixin, which is not possible because our transformer is a transformer and not a classifier. So I had to de-activate the tests for this transformer for versions 1.7.0 and onwards.