### PR TITLE
[ENH] defer trailing underscore attribute assignment in fit() for imputers and discretisers

### DIFF
--- a/feature_engine/_base_transformers/base_numerical.py
+++ b/feature_engine/_base_transformers/base_numerical.py
@@ -28,6 +28,26 @@ class BaseNumericalTransformer(
     variable transformers, discretisers, math combination.
     """
 
+    def _fit_setup(self, X: pd.DataFrame):
+        """
+        Check dataframe, find numerical variables, check for NA and Inf.
+        Returns the checked dataframe and the correctly identified numerical variables.
+        """
+        # check input dataframe
+        X = check_X(X)
+
+        # find or check for numerical variables
+        if self.variables is None:
+            variables_ = find_numerical_variables(X)
+        else:
+            variables_ = check_numerical_variables(X, self.variables)
+
+        # check if dataset contains na or inf
+        _check_contains_na(X, variables_)
+        _check_contains_inf(X, variables_)
+
+        return X, variables_
+
     def fit(self, X: pd.DataFrame) -> pd.DataFrame:
         """
         Checks that input is a dataframe, finds numerical variables, or alternatively
@@ -55,18 +75,9 @@ class BaseNumericalTransformer(
             The same dataframe entered as parameter
         """
 
-        # check input dataframe
-        X = check_X(X)
+        X, variables_ = self._fit_setup(X)
 
-        # find or check for numerical variables
-        if self.variables is None:
-            self.variables_ = find_numerical_variables(X)
-        else:
-            self.variables_ = check_numerical_variables(X, self.variables)
-
-        # check if dataset contains na or inf
-        _check_contains_na(X, self.variables_)
-        _check_contains_inf(X, self.variables_)
+        self.variables_ = variables_
 
         # save input features
         self.feature_names_in_ = X.columns.tolist()

--- a/feature_engine/_base_transformers/base_numerical.py
+++ b/feature_engine/_base_transformers/base_numerical.py
@@ -48,44 +48,14 @@ class BaseNumericalTransformer(
 
         return X, variables_
 
-    def fit(self, X: pd.DataFrame) -> pd.DataFrame:
-        """
-        Checks that input is a dataframe, finds numerical variables, or alternatively
-        checks that variables entered by the user are of type numerical.
+    def _get_feature_names_in(self, X):
+        """Get the names and number of features in the train set (the dataframe
+        used during fit)."""
 
-        Parameters
-        ----------
-        X : Pandas DataFrame
-
-        y : Pandas Series, np.array. Default = None
-            Parameter is necessary for compatibility with sklearn Pipeline.
-
-        Raises
-        ------
-        TypeError
-            If the input is not a Pandas DataFrame or a numpy array
-            If any of the user provided variables are not numerical
-        ValueError
-            If there are no numerical variables in the df or the df is empty
-            If the variable(s) contain null values
-
-        Returns
-        -------
-        X : Pandas DataFrame
-            The same dataframe entered as parameter
-        """
-
-        X, variables_ = self._fit_setup(X)
-
-        self.variables_ = variables_
-
-        # save input features
-        self.feature_names_in_ = X.columns.tolist()
-
-        # save train set shape
+        self.feature_names_in_ = X.columns.to_list()
         self.n_features_in_ = X.shape[1]
 
-        return X
+        return self
 
     def _check_transform_input_and_state(self, X: pd.DataFrame) -> pd.DataFrame:
         """

--- a/feature_engine/_base_transformers/base_numerical.py
+++ b/feature_engine/_base_transformers/base_numerical.py
@@ -28,17 +28,17 @@ class BaseNumericalTransformer(
     variable transformers, discretisers, math combination.
     """
 
-    def fit(self, X: pd.DataFrame) -> pd.DataFrame:
+    def _fit_setup(self, X: pd.DataFrame):
         """
         Checks that input is a dataframe, finds numerical variables, or alternatively
-        checks that variables entered by the user are of type numerical.
+        checks that variables entered by the user are of type numerical, and checks
+        for NA and Inf. Does not assign any trailing-underscore attribute, so that
+        subclasses can defer attribute assignment until the rest of their fit logic
+        has completed successfully.
 
         Parameters
         ----------
         X : Pandas DataFrame
-
-        y : Pandas Series, np.array. Default = None
-            Parameter is necessary for compatibility with sklearn Pipeline.
 
         Raises
         ------
@@ -53,6 +53,9 @@ class BaseNumericalTransformer(
         -------
         X : Pandas DataFrame
             The same dataframe entered as parameter
+
+        variables_ : List
+            The variables that were found or checked.
         """
 
         # check input dataframe
@@ -60,23 +63,24 @@ class BaseNumericalTransformer(
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(
-                X, return_empty=self.return_empty
-            )
+            variables_ = find_numerical_variables(X, return_empty=self.return_empty)
         else:
-            self.variables_ = check_numerical_variables(X, self.variables)
+            variables_ = check_numerical_variables(X, self.variables)
 
         # check if dataset contains na or inf
-        _check_contains_na(X, self.variables_)
-        _check_contains_inf(X, self.variables_)
+        _check_contains_na(X, variables_)
+        _check_contains_inf(X, variables_)
 
-        # save input features
+        return X, variables_
+
+    def _get_feature_names_in(self, X):
+        """Get the names and number of features in the train set (the dataframe
+        used during fit)."""
+
         self.feature_names_in_ = X.columns.tolist()
-
-        # save train set shape
         self.n_features_in_ = X.shape[1]
 
-        return X
+        return self
 
     def _check_transform_input_and_state(self, X: pd.DataFrame) -> pd.DataFrame:
         """

--- a/feature_engine/_base_transformers/mixins.py
+++ b/feature_engine/_base_transformers/mixins.py
@@ -77,17 +77,14 @@ class FitFromDictMixin:
 
         # find or check for numerical variables
         variables = list(user_dict_.keys())
-        self.variables_ = check_numerical_variables(X, variables)
+        variables_ = check_numerical_variables(X, variables)
 
         # check if dataset contains na or inf
-        _check_contains_na(X, self.variables_)
-        _check_contains_inf(X, self.variables_)
+        _check_contains_na(X, variables_)
+        _check_contains_inf(X, variables_)
 
-        # save input features
-        self.feature_names_in_ = X.columns.tolist()
-
-        # save train set shape
-        self.n_features_in_ = X.shape[1]
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return X
 

--- a/feature_engine/_base_transformers/mixins.py
+++ b/feature_engine/_base_transformers/mixins.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import pandas as pd
 from numpy import ndarray
@@ -46,7 +46,9 @@ class TransformXyMixin:
 
 
 class FitFromDictMixin:
-    def _fit_from_dict(self, X: pd.DataFrame, user_dict_: Dict) -> pd.DataFrame:
+    def _fit_from_dict(
+        self, X: pd.DataFrame, user_dict_: Dict
+    ) -> Tuple[pd.DataFrame, List[Union[str, int]]]:
         """
         Checks that input is a dataframe, checks that variables in the dictionary
         entered by the user are of type numerical.
@@ -71,6 +73,9 @@ class FitFromDictMixin:
         -------
         X : Pandas DataFrame
             The same dataframe entered as parameter
+
+        variables_ : List
+            The variables in the dictionary.
         """
         # check input dataframe
         X = check_X(X)
@@ -83,10 +88,7 @@ class FitFromDictMixin:
         _check_contains_na(X, variables_)
         _check_contains_inf(X, variables_)
 
-        self.variables_ = variables_
-        self._get_feature_names_in(X)
-
-        return X
+        return X, variables_
 
 
 class GetFeatureNamesOutMixin:

--- a/feature_engine/_base_transformers/mixins.py
+++ b/feature_engine/_base_transformers/mixins.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import pandas as pd
 from numpy import ndarray
@@ -46,10 +46,14 @@ class TransformXyMixin:
 
 
 class FitFromDictMixin:
-    def _fit_from_dict(self, X: pd.DataFrame, user_dict_: Dict) -> pd.DataFrame:
+    def _fit_from_dict(
+        self, X: pd.DataFrame, user_dict_: Dict
+    ) -> Tuple[pd.DataFrame, List[Union[str, int]]]:
         """
         Checks that input is a dataframe, checks that variables in the dictionary
-        entered by the user are of type numerical.
+        entered by the user are of type numerical. Does not assign any
+        trailing-underscore attribute, so that subclasses can defer attribute
+        assignment until the rest of their fit logic has completed successfully.
 
         Parameters
         ----------
@@ -71,25 +75,22 @@ class FitFromDictMixin:
         -------
         X : Pandas DataFrame
             The same dataframe entered as parameter
+
+        variables_ : List
+            The variables in the dictionary.
         """
         # check input dataframe
         X = check_X(X)
 
         # find or check for numerical variables
         variables = list(user_dict_.keys())
-        self.variables_ = check_numerical_variables(X, variables)
+        variables_ = check_numerical_variables(X, variables)
 
         # check if dataset contains na or inf
-        _check_contains_na(X, self.variables_)
-        _check_contains_inf(X, self.variables_)
+        _check_contains_na(X, variables_)
+        _check_contains_inf(X, variables_)
 
-        # save input features
-        self.feature_names_in_ = X.columns.tolist()
-
-        # save train set shape
-        self.n_features_in_ = X.shape[1]
-
-        return X
+        return X, variables_
 
 
 class GetFeatureNamesOutMixin:

--- a/feature_engine/creation/cyclical_features.py
+++ b/feature_engine/creation/cyclical_features.py
@@ -146,13 +146,11 @@ class CyclicalFeatures(
         y: pandas Series, default=None
             It is not needed in this transformer. You can pass y or None.
         """
-        variables_: List[Union[str, int]]
         if self.max_values is None:
             X, variables_ = self._fit_setup(X)
             max_values_ = X[variables_].max().to_dict()
         else:
-            X = super()._fit_from_dict(X, self.max_values)
-            variables_ = self.variables  # type: ignore
+            X, variables_ = super()._fit_from_dict(X, self.max_values)
             max_values_ = self.max_values
 
         self.variables_ = variables_

--- a/feature_engine/creation/cyclical_features.py
+++ b/feature_engine/creation/cyclical_features.py
@@ -147,11 +147,16 @@ class CyclicalFeatures(
             It is not needed in this transformer. You can pass y or None.
         """
         if self.max_values is None:
-            X = super().fit(X)
-            self.max_values_ = X[self.variables_].max().to_dict()
+            X, variables_ = self._fit_setup(X)
+            max_values_ = X[variables_].max().to_dict()
         else:
-            super()._fit_from_dict(X, self.max_values)
-            self.max_values_ = self.max_values
+            X = super()._fit_from_dict(X, self.max_values)
+            variables_ = self.variables_
+            max_values_ = self.max_values
+
+        self.variables_ = variables_
+        self.max_values_ = max_values_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/creation/cyclical_features.py
+++ b/feature_engine/creation/cyclical_features.py
@@ -146,12 +146,13 @@ class CyclicalFeatures(
         y: pandas Series, default=None
             It is not needed in this transformer. You can pass y or None.
         """
+        variables_: List[Union[str, int]]
         if self.max_values is None:
             X, variables_ = self._fit_setup(X)
             max_values_ = X[variables_].max().to_dict()
         else:
             X = super()._fit_from_dict(X, self.max_values)
-            variables_ = self.variables_
+            variables_ = self.variables  # type: ignore
             max_values_ = self.max_values
 
         self.variables_ = variables_

--- a/feature_engine/creation/cyclical_features.py
+++ b/feature_engine/creation/cyclical_features.py
@@ -155,11 +155,15 @@ class CyclicalFeatures(
             It is not needed in this transformer. You can pass y or None.
         """
         if self.max_values is None:
-            X = super().fit(X)
-            self.max_values_ = X[self.variables_].max().to_dict()
+            X, variables_ = self._fit_setup(X)
+            max_values_ = X[variables_].max().to_dict()
         else:
-            super()._fit_from_dict(X, self.max_values)
-            self.max_values_ = self.max_values
+            X, variables_ = super()._fit_from_dict(X, self.max_values)
+            max_values_ = self.max_values
+
+        self.variables_ = variables_
+        self.max_values_ = max_values_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/creation/decision_tree_features.py
+++ b/feature_engine/creation/decision_tree_features.py
@@ -260,9 +260,7 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
         y: pandas Series or np.array = [n_samples,]
             The target variable that is used to train the decision tree.
         """
-        y = pd.Series(y)
-
-        # confirm model type and target variables are compatible.
+        X, y = check_X_y(X, y)
         if self.regression is True:
             if type_of_target(y) == "binary":
                 raise ValueError(
@@ -275,15 +273,12 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
             check_classification_targets(y)
             is_binary = type_of_target(y)
 
-        X, y = check_X_y(X, y)
-
         # find or check for numerical variables
         if self.variables is None:
             variables_ = find_numerical_variables(X)
         else:
             variables_ = check_numerical_variables(X, self.variables)
 
-        # check if dataset contains na or inf
         _check_contains_na(X, variables_)
         _check_contains_inf(X, variables_)
 
@@ -292,7 +287,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
         else:
             param_grid = {"max_depth": [1, 2, 3, 4]}
 
-        # get the sets of variables that will be used to create new features
         input_features = self._create_variable_combinations(
             how_to_combine=self.features_to_combine, variables=variables_
         )
@@ -301,7 +295,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
         for features in input_features:
             estimator = self._make_decision_tree(param_grid=param_grid)
 
-            # single feature models
             if isinstance(features, str):
                 estimator.fit(X[features].to_frame(), y)
             # multi feature models
@@ -334,24 +327,17 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
             Either the original dataframe plus the new features or
             a dataframe of only the new features.
         """
-        # Check method fit has been called
         check_is_fitted(self)
 
-        # check that input is a dataframe
         X = check_X(X)
 
-        # Check if input data contains same number of columns as dataframe used to fit.
         _check_X_matches_training_df(X, self.n_features_in_)
 
-        # check if dataset contains na or inf
         _check_contains_na(X, self.variables_)
         _check_contains_inf(X, self.variables_)
 
-        # reorder variables to match train set
         X = X[self.feature_names_in_]
 
-        # create new features and add them to the original dataframe
-        # if regression or multiclass, we return the output of predict()
         if self.regression is True:
             for features, estimator in zip(self.input_features_, self.estimators_):
                 if isinstance(features, str):
@@ -365,7 +351,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
                         preds = np.round(preds, self.precision)
                     X.loc[:, f"tree({features})"] = preds
 
-        # if binary classification, we return the probability
         elif self._is_binary == "binary":
             for features, estimator in zip(self.input_features_, self.estimators_):
                 if isinstance(features, str):
@@ -379,7 +364,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
                         preds = np.round(preds, self.precision)
                     X.loc[:, f"tree({features})"] = preds[:, 1]
 
-        # if multiclass, we return the output of predict()
         else:
             for features, estimator in zip(self.input_features_, self.estimators_):
                 if isinstance(features, str):
@@ -441,7 +425,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
                 else:
                     combos.append(list(feature))
 
-        # if output_features is None, int or list.
         else:
             if how_to_combine is None:
                 if len(variables) == 1:
@@ -456,7 +439,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
                     els = [list(x) for x in itertools.combinations(variables, i)]
                     combos += els
 
-            # output_feature is a list
             else:
                 for i in how_to_combine:
                     els = [list(x) for x in itertools.combinations(variables, i)]
@@ -469,7 +451,6 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
         feature_names = [f"tree({combo})" for combo in self.input_features_]
         return feature_names
 
-    # for the check_estimator tests
     def _more_tags(self):
         tags_dict = _return_tags()
         tags_dict["requires_y"] = True

--- a/feature_engine/creation/decision_tree_features.py
+++ b/feature_engine/creation/decision_tree_features.py
@@ -260,6 +260,8 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
         y: pandas Series or np.array = [n_samples,]
             The target variable that is used to train the decision tree.
         """
+        y = pd.Series(y)
+
         # confirm model type and target variables are compatible.
         if self.regression is True:
             if type_of_target(y) == "binary":
@@ -268,9 +270,10 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
                     "allowed by this transformer. Check the target values "
                     "or set regression to False."
                 )
+            is_binary = None
         else:
             check_classification_targets(y)
-            self._is_binary = type_of_target(y)
+            is_binary = type_of_target(y)
 
         X, y = check_X_y(X, y)
 
@@ -310,6 +313,7 @@ class DecisionTreeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMi
         self.variables_ = variables_
         self.input_features_ = input_features
         self.estimators_ = estimators_
+        self._is_binary = is_binary
         self.feature_names_in_ = X.columns.tolist()
         self.n_features_in_ = X.shape[1]
 

--- a/feature_engine/creation/geo_features.py
+++ b/feature_engine/creation/geo_features.py
@@ -234,7 +234,7 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
         # check input dataframe
         X = check_X(X)
 
-        variables = [
+        variables: List[Union[str, int]] = [
             self.lat1,
             self.lon1,
             self.lat2,

--- a/feature_engine/creation/geo_features.py
+++ b/feature_engine/creation/geo_features.py
@@ -234,8 +234,7 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
         # check input dataframe
         X = check_X(X)
 
-        # Store coordinate variables
-        self.variables_: List[Union[str, int]] = [
+        variables = [
             self.lat1,
             self.lon1,
             self.lat2,
@@ -243,17 +242,17 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
         ]
 
         # Check all coordinate columns exist
-        missing = set(self.variables_) - set(X.columns)
+        missing = set(variables) - set(X.columns)
         if missing:
             raise ValueError(
                 f"Coordinate columns {missing} are not present in the dataframe."
             )
 
         # Check coordinate columns are numerical
-        check_numerical_variables(X, self.variables_)
+        check_numerical_variables(X, variables)
 
         # Check for missing values
-        _check_contains_na(X, self.variables_)
+        _check_contains_na(X, variables)
 
         # Validate coordinate ranges if enabled
         if self.validate_ranges:
@@ -268,6 +267,9 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
                     raise ValueError(
                         f"Longitude values in '{lon_col}' must be between -180 and 180."
                     )
+
+        # save coordinate variables
+        self.variables_ = variables
 
         # save input features
         self.feature_names_in_ = X.columns.tolist()

--- a/feature_engine/creation/geo_features.py
+++ b/feature_engine/creation/geo_features.py
@@ -234,8 +234,8 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
         # check input dataframe
         X = check_X(X)
 
-        # Store coordinate variables
-        self.variables_: List[Union[str, int]] = [
+        # Coordinate variables
+        variables: List[Union[str, int]] = [
             self.lat1,
             self.lon1,
             self.lat2,
@@ -243,17 +243,17 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
         ]
 
         # Check all coordinate columns exist
-        missing = set(self.variables_) - set(X.columns)
+        missing = set(variables) - set(X.columns)
         if missing:
             raise ValueError(
                 f"Coordinate columns {missing} are not present in the dataframe."
             )
 
         # Check coordinate columns are numerical
-        check_numerical_variables(X, self.variables_)
+        check_numerical_variables(X, variables)
 
         # Check for missing values
-        _check_contains_na(X, self.variables_)
+        _check_contains_na(X, variables)
 
         # Validate coordinate ranges if enabled
         if self.validate_ranges:
@@ -268,6 +268,9 @@ class GeoDistanceFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMix
                     raise ValueError(
                         f"Longitude values in '{lon_col}' must be between -180 and 180."
                     )
+
+        # save coordinate variables
+        self.variables_ = variables
 
         # save input features
         self.feature_names_in_ = X.columns.tolist()

--- a/feature_engine/discretisation/arbitrary.py
+++ b/feature_engine/discretisation/arbitrary.py
@@ -155,6 +155,7 @@ class ArbitraryDiscretiser(BaseDiscretiser, FitFromDictMixin):
 
         # for consistency wit the rest of the discretisers, we add this attribute
         self.binner_dict_ = self.binning_dict
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/discretisation/arbitrary.py
+++ b/feature_engine/discretisation/arbitrary.py
@@ -151,9 +151,10 @@ class ArbitraryDiscretiser(BaseDiscretiser, FitFromDictMixin):
             y is not needed in this transformer. You can pass y or None.
         """
         # check input dataframe
-        X = super()._fit_from_dict(X, self.binning_dict)
+        X, variables_ = super()._fit_from_dict(X, self.binning_dict)
 
         # for consistency wit the rest of the discretisers, we add this attribute
+        self.variables_ = variables_
         self.binner_dict_ = self.binning_dict
         self._get_feature_names_in(X)
 

--- a/feature_engine/discretisation/arbitrary.py
+++ b/feature_engine/discretisation/arbitrary.py
@@ -152,10 +152,12 @@ class ArbitraryDiscretiser(BaseDiscretiser, FitFromDictMixin):
             y is not needed in this transformer. You can pass y or None.
         """
         # check input dataframe
-        X = super()._fit_from_dict(X, self.binning_dict)
+        X, variables_ = super()._fit_from_dict(X, self.binning_dict)
 
+        self.variables_ = variables_
         # for consistency with the rest of the discretisers, we add this attribute
         self.binner_dict_ = self.binning_dict
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/discretisation/base_discretiser.py
+++ b/feature_engine/discretisation/base_discretiser.py
@@ -10,7 +10,8 @@ class BaseDiscretiser(BaseNumericalTransformer):
     """
     Shared set-up checks and methods across numerical discretisers.
 
-    Important: inherits fit() functionality and tags from BaseNumericalTransformer.
+    Important: inherits _fit_setup(), _get_feature_names_in() and tags from
+    BaseNumericalTransformer. Subclasses implement fit() themselves.
     """
 
     def __init__(

--- a/feature_engine/discretisation/decision_tree.py
+++ b/feature_engine/discretisation/decision_tree.py
@@ -241,7 +241,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
             check_classification_targets(y)
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         if self.param_grid:
             param_grid = self.param_grid
@@ -251,7 +251,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
         binner_dict_ = {}
         scores_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
 
             if self.regression:
                 model = DecisionTreeRegressor(random_state=self.random_state)
@@ -269,7 +269,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
             scores_dict_[var] = tree_model.score(X[var].to_frame(), y)
 
         if self.bin_output != "prediction":
-            for var in self.variables_:
+            for var in variables_:
                 clf = binner_dict_[var].best_estimator_
                 threshold = clf.tree_.threshold
                 feature = clf.tree_.feature
@@ -280,6 +280,9 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
 
         self.binner_dict_ = binner_dict_
         self.scores_dict_ = scores_dict_
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
+
         return self
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:

--- a/feature_engine/discretisation/decision_tree.py
+++ b/feature_engine/discretisation/decision_tree.py
@@ -214,7 +214,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
         self.param_grid = param_grid
         self.random_state = random_state
 
-    def fit(self, X: pd.DataFrame, y: pd.Series):  # type: ignore
+    def fit(self, X: pd.DataFrame, y: pd.Series):
         """
         Fit one decision tree per variable to discretize with cross-validation and
         grid-search for hyperparameters.

--- a/feature_engine/discretisation/decision_tree.py
+++ b/feature_engine/discretisation/decision_tree.py
@@ -225,7 +225,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
         self.random_state = random_state
         self.return_empty = return_empty
 
-    def fit(self, X: pd.DataFrame, y: pd.Series):  # type: ignore
+    def fit(self, X: pd.DataFrame, y: pd.Series):
         """
         Fit one decision tree per variable to discretise with cross-validation and
         grid-search for hyperparameters.
@@ -252,7 +252,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
             check_classification_targets(y)
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         if self.param_grid:
             param_grid = self.param_grid
@@ -262,7 +262,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
         binner_dict_ = {}
         scores_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
 
             if self.regression:
                 model = DecisionTreeRegressor(random_state=self.random_state)
@@ -280,7 +280,7 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
             scores_dict_[var] = tree_model.score(X[var].to_frame(), y)
 
         if self.bin_output != "prediction":
-            for var in self.variables_:
+            for var in variables_:
                 clf = binner_dict_[var].best_estimator_
                 threshold = clf.tree_.threshold
                 feature = clf.tree_.feature
@@ -291,6 +291,9 @@ class DecisionTreeDiscretiser(BaseNumericalTransformer):
 
         self.binner_dict_ = binner_dict_
         self.scores_dict_ = scores_dict_
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
+
         return self
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:

--- a/feature_engine/discretisation/equal_frequency.py
+++ b/feature_engine/discretisation/equal_frequency.py
@@ -159,17 +159,21 @@ class EqualFrequencyDiscretiser(BaseDiscretiser):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
-        self.binner_dict_ = {}
+        binner_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
             tmp, bins = pd.qcut(x=X[var], q=self.q, retbins=True, duplicates="drop")
 
             # Prepend/Append infinities to accommodate outliers
             bins = list(bins)
             bins[0] = float("-inf")
             bins[len(bins) - 1] = float("inf")
-            self.binner_dict_[var] = bins
+            binner_dict_[var] = bins
 
+        self.binner_dict_ = binner_dict_
+        self.variables_ = variables_
+        self.feature_names_in_ = X.columns.tolist()
+        self.n_features_in_ = X.shape[1]
         return self

--- a/feature_engine/discretisation/equal_frequency.py
+++ b/feature_engine/discretisation/equal_frequency.py
@@ -174,6 +174,5 @@ class EqualFrequencyDiscretiser(BaseDiscretiser):
 
         self.binner_dict_ = binner_dict_
         self.variables_ = variables_
-        self.feature_names_in_ = X.columns.tolist()
-        self.n_features_in_ = X.shape[1]
+        self._get_feature_names_in(X)
         return self

--- a/feature_engine/discretisation/equal_frequency.py
+++ b/feature_engine/discretisation/equal_frequency.py
@@ -170,17 +170,21 @@ class EqualFrequencyDiscretiser(BaseDiscretiser):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
-        self.binner_dict_ = {}
+        binner_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
             tmp, bins = pd.qcut(x=X[var], q=self.q, retbins=True, duplicates="drop")
 
             # Prepend/Append infinities to accommodate outliers
             bins = list(bins)
             bins[0] = float("-inf")
             bins[len(bins) - 1] = float("inf")
-            self.binner_dict_[var] = bins
+            binner_dict_[var] = bins
+
+        self.binner_dict_ = binner_dict_
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/discretisation/equal_width.py
+++ b/feature_engine/discretisation/equal_width.py
@@ -190,6 +190,5 @@ class EqualWidthDiscretiser(BaseDiscretiser):
 
         self.binner_dict_ = binner_dict_
         self.variables_ = variables_
-        self.feature_names_in_ = X.columns.tolist()
-        self.n_features_in_ = X.shape[1]
+        self._get_feature_names_in(X)
         return self

--- a/feature_engine/discretisation/equal_width.py
+++ b/feature_engine/discretisation/equal_width.py
@@ -168,12 +168,12 @@ class EqualWidthDiscretiser(BaseDiscretiser):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         # fit
-        self.binner_dict_ = {}
+        binner_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
             tmp, bins = pd.cut(
                 x=X[var],
                 bins=self.bins,
@@ -186,6 +186,10 @@ class EqualWidthDiscretiser(BaseDiscretiser):
             bins = list(bins)
             bins[0] = float("-inf")
             bins[len(bins) - 1] = float("inf")
-            self.binner_dict_[var] = bins
+            binner_dict_[var] = bins
 
+        self.binner_dict_ = binner_dict_
+        self.variables_ = variables_
+        self.feature_names_in_ = X.columns.tolist()
+        self.n_features_in_ = X.shape[1]
         return self

--- a/feature_engine/discretisation/equal_width.py
+++ b/feature_engine/discretisation/equal_width.py
@@ -179,12 +179,12 @@ class EqualWidthDiscretiser(BaseDiscretiser):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         # fit
-        self.binner_dict_ = {}
+        binner_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
             tmp, bins = pd.cut(
                 x=X[var],
                 bins=self.bins,
@@ -197,6 +197,10 @@ class EqualWidthDiscretiser(BaseDiscretiser):
             bins = list(bins)
             bins[0] = float("-inf")
             bins[len(bins) - 1] = float("inf")
-            self.binner_dict_[var] = bins
+            binner_dict_[var] = bins
+
+        self.binner_dict_ = binner_dict_
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/discretisation/geometric_width.py
+++ b/feature_engine/discretisation/geometric_width.py
@@ -159,12 +159,12 @@ class GeometricWidthDiscretiser(BaseDiscretiser):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         # fit
-        self.binner_dict_ = {}
+        binner_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
             min_, max_ = X[var].min(), X[var].max()
             increment = np.power(max_ - min_, 1.0 / self.bins)
             bins = np.r_[
@@ -172,6 +172,10 @@ class GeometricWidthDiscretiser(BaseDiscretiser):
             ]
             bins = np.sort(bins)
             bins = list(bins)
-            self.binner_dict_[var] = bins
+            binner_dict_[var] = bins
+
+        self.variables_ = variables_
+        self.binner_dict_ = binner_dict_
+        self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/discretisation/geometric_width.py
+++ b/feature_engine/discretisation/geometric_width.py
@@ -174,12 +174,12 @@ class GeometricWidthDiscretiser(BaseDiscretiser):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         # fit
-        self.binner_dict_ = {}
+        binner_dict_ = {}
 
-        for var in self.variables_:
+        for var in variables_:
             min_, max_ = X[var].min(), X[var].max()
             increment = np.power(max_ - min_, 1.0 / self.bins)
             bins = np.r_[
@@ -187,6 +187,10 @@ class GeometricWidthDiscretiser(BaseDiscretiser):
             ]
             bins = np.sort(bins)
             bins = list(bins)
-            self.binner_dict_[var] = bins
+            binner_dict_[var] = bins
+
+        self.binner_dict_ = binner_dict_
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/arbitrary_imputer.py
+++ b/feature_engine/imputation/arbitrary_imputer.py
@@ -163,17 +163,19 @@ class ArbitraryImputer(BaseImputer):
         # find or check for numerical variables
         # create the imputer dictionary
         if self.imputer_dict:
-            self.variables_ = check_numerical_variables(
+            variables_ = check_numerical_variables(
                 X, list(self.imputer_dict.keys())
             )
-            self.imputer_dict_ = self.imputer_dict
+            imputer_dict_ = self.imputer_dict
         else:
             if self.variables is None:
-                self.variables_ = find_numerical_variables(X, self.return_empty)
+                variables_ = find_numerical_variables(X, self.return_empty)
             else:
-                self.variables_ = check_numerical_variables(X, self.variables)
-            self.imputer_dict_ = {var: self.arbitrary_number for var in self.variables_}
+                variables_ = check_numerical_variables(X, self.variables)
+            imputer_dict_ = {var: self.arbitrary_number for var in variables_}
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/arbitrary_number.py
+++ b/feature_engine/imputation/arbitrary_number.py
@@ -149,17 +149,19 @@ class ArbitraryNumberImputer(BaseImputer):
         # find or check for numerical variables
         # create the imputer dictionary
         if self.imputer_dict:
-            self.variables_ = check_numerical_variables(
+            variables_ = check_numerical_variables(
                 X, list(self.imputer_dict.keys())
             )
-            self.imputer_dict_ = self.imputer_dict
+            imputer_dict_ = self.imputer_dict
         else:
             if self.variables is None:
-                self.variables_ = find_numerical_variables(X)
+                variables_ = find_numerical_variables(X)
             else:
-                self.variables_ = check_numerical_variables(X, self.variables)
-            self.imputer_dict_ = {var: self.arbitrary_number for var in self.variables_}
+                variables_ = check_numerical_variables(X, self.variables)
+            imputer_dict_ = {var: self.arbitrary_number for var in variables_}
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/categorical.py
+++ b/feature_engine/imputation/categorical.py
@@ -169,22 +169,22 @@ class CategoricalImputer(BaseImputer):
         # select variables to encode
         if self.ignore_format is True:
             if self.variables is None:
-                self.variables_ = find_all_variables(X)
+                variables_ = find_all_variables(X)
             else:
-                self.variables_ = check_all_variables(X, self.variables)
+                variables_ = check_all_variables(X, self.variables)
         else:
             if self.variables is None:
-                self.variables_ = find_categorical_variables(X)
+                variables_ = find_categorical_variables(X)
             else:
-                self.variables_ = check_categorical_variables(X, self.variables)
+                variables_ = check_categorical_variables(X, self.variables)
 
         if self.imputation_method == "missing":
-            self.imputer_dict_ = {var: self.fill_value for var in self.variables_}
+            imputer_dict_ = {var: self.fill_value for var in variables_}
 
         elif self.imputation_method == "frequent":
             # if imputing only 1 variable:
-            if len(self.variables_) == 1:
-                var = self.variables_[0]
+            if len(variables_) == 1:
+                var = variables_[0]
                 mode_vals = X[var].mode()
 
                 # Some variables may contain more than 1 mode:
@@ -193,13 +193,13 @@ class CategoricalImputer(BaseImputer):
                         f"The variable {var} contains multiple frequent categories."
                     )
 
-                self.imputer_dict_ = {var: mode_vals[0]}
+                imputer_dict_ = {var: mode_vals[0]}
 
             # imputing multiple variables:
             else:
                 # Returns a dataframe with 1 row if there is one mode per
                 # variable, or more rows if there are more modes:
-                mode_vals = X[self.variables_].mode()
+                mode_vals = X[variables_].mode()
 
                 # Careful: some variables contain multiple modes
                 if len(mode_vals) > 1:
@@ -213,8 +213,10 @@ class CategoricalImputer(BaseImputer):
                         f"categories."
                     )
 
-                self.imputer_dict_ = mode_vals.iloc[0].to_dict()
+                imputer_dict_ = mode_vals.iloc[0].to_dict()
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/categorical.py
+++ b/feature_engine/imputation/categorical.py
@@ -181,22 +181,22 @@ class CategoricalImputer(BaseImputer):
         # select variables to encode
         if self.ignore_format is True:
             if self.variables is None:
-                self.variables_ = find_all_variables(X, self.return_empty)
+                variables_ = find_all_variables(X, self.return_empty)
             else:
-                self.variables_ = check_all_variables(X, self.variables)
+                variables_ = check_all_variables(X, self.variables)
         else:
             if self.variables is None:
-                self.variables_ = find_categorical_variables(X, self.return_empty)
+                variables_ = find_categorical_variables(X, self.return_empty)
             else:
-                self.variables_ = check_categorical_variables(X, self.variables)
+                variables_ = check_categorical_variables(X, self.variables)
 
         if self.imputation_method == "missing":
-            self.imputer_dict_ = {var: self.fill_value for var in self.variables_}
+            imputer_dict_ = {var: self.fill_value for var in variables_}
 
         elif self.imputation_method == "frequent":
             # if imputing only 1 variable:
-            if len(self.variables_) == 1:
-                var = self.variables_[0]
+            if len(variables_) == 1:
+                var = variables_[0]
                 mode_vals = X[var].mode()
 
                 # Some variables may contain more than 1 mode:
@@ -205,13 +205,13 @@ class CategoricalImputer(BaseImputer):
                         f"The variable {var} contains multiple frequent categories."
                     )
 
-                self.imputer_dict_ = {var: mode_vals[0]}
+                imputer_dict_ = {var: mode_vals[0]}
 
             # imputing multiple variables:
             else:
                 # Returns a dataframe with 1 row if there is one mode per
                 # variable, or more rows if there are more modes:
-                mode_vals = X[self.variables_].mode()
+                mode_vals = X[variables_].mode()
 
                 # Careful: some variables contain multiple modes
                 if len(mode_vals) > 1:
@@ -225,8 +225,10 @@ class CategoricalImputer(BaseImputer):
                         f"categories."
                     )
 
-                self.imputer_dict_ = mode_vals.iloc[0].to_dict()
+                imputer_dict_ = mode_vals.iloc[0].to_dict()
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/drop_missing_data.py
+++ b/feature_engine/imputation/drop_missing_data.py
@@ -150,16 +150,17 @@ class DropMissingData(BaseImputer, TransformXyMixin):
 
         # find variables for which indicator should be added
         if self.variables is None:
-            self.variables_ = find_all_variables(X)
+            variables_ = find_all_variables(X)
         else:
-            self.variables_ = check_all_variables(X, self.variables)
+            variables_ = check_all_variables(X, self.variables)
 
         # If user passes a threshold, then missing_only is ignored:
         if self.threshold is None and self.missing_only is True:
-            self.variables_ = [
-                var for var in self.variables_ if X[var].isnull().sum() > 0
+            variables_ = [
+                var for var in variables_ if X[var].isnull().sum() > 0
             ]
 
+        self.variables_ = variables_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/drop_missing_data.py
+++ b/feature_engine/imputation/drop_missing_data.py
@@ -163,16 +163,15 @@ class DropMissingData(BaseImputer, TransformXyMixin):
 
         # find variables for which indicator should be added
         if self.variables is None:
-            self.variables_ = find_all_variables(X, self.return_empty)
+            variables_ = find_all_variables(X, self.return_empty)
         else:
-            self.variables_ = check_all_variables(X, self.variables)
+            variables_ = check_all_variables(X, self.variables)
 
         # If user passes a threshold, then missing_only is ignored:
         if self.threshold is None and self.missing_only is True:
-            self.variables_ = [
-                var for var in self.variables_ if X[var].isnull().sum() > 0
-            ]
+            variables_ = [var for var in variables_ if X[var].isnull().sum() > 0]
 
+        self.variables_ = variables_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/end_tail.py
+++ b/feature_engine/imputation/end_tail.py
@@ -177,35 +177,37 @@ class EndTailImputer(BaseImputer):
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(X)
+            variables_ = find_numerical_variables(X)
         else:
-            self.variables_ = check_numerical_variables(X, self.variables)
+            variables_ = check_numerical_variables(X, self.variables)
 
         # estimate imputation values
         if self.imputation_method == "max":
-            self.imputer_dict_ = (X[self.variables_].max() * self.fold).to_dict()
+            imputer_dict_ = (X[variables_].max() * self.fold).to_dict()
 
         elif self.imputation_method == "gaussian":
             if self.tail == "right":
-                self.imputer_dict_ = (
-                    X[self.variables_].mean() + self.fold * X[self.variables_].std()
+                imputer_dict_ = (
+                    X[variables_].mean() + self.fold * X[variables_].std()
                 ).to_dict()
             elif self.tail == "left":
-                self.imputer_dict_ = (
-                    X[self.variables_].mean() - self.fold * X[self.variables_].std()
+                imputer_dict_ = (
+                    X[variables_].mean() - self.fold * X[variables_].std()
                 ).to_dict()
 
         elif self.imputation_method == "iqr":
-            IQR = X[self.variables_].quantile(0.75) - X[self.variables_].quantile(0.25)
+            IQR = X[variables_].quantile(0.75) - X[variables_].quantile(0.25)
             if self.tail == "right":
-                self.imputer_dict_ = (
-                    X[self.variables_].quantile(0.75) + (IQR * self.fold)
+                imputer_dict_ = (
+                    X[variables_].quantile(0.75) + (IQR * self.fold)
                 ).to_dict()
             elif self.tail == "left":
-                self.imputer_dict_ = (
-                    X[self.variables_].quantile(0.25) - (IQR * self.fold)
+                imputer_dict_ = (
+                    X[variables_].quantile(0.25) - (IQR * self.fold)
                 ).to_dict()
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/end_tail.py
+++ b/feature_engine/imputation/end_tail.py
@@ -187,35 +187,37 @@ class EndTailImputer(BaseImputer):
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(X, self.return_empty)
+            variables_ = find_numerical_variables(X, self.return_empty)
         else:
-            self.variables_ = check_numerical_variables(X, self.variables)
+            variables_ = check_numerical_variables(X, self.variables)
 
         # estimate imputation values
         if self.imputation_method == "max":
-            self.imputer_dict_ = (X[self.variables_].max() * self.fold).to_dict()
+            imputer_dict_ = (X[variables_].max() * self.fold).to_dict()
 
         elif self.imputation_method == "gaussian":
             if self.tail == "right":
-                self.imputer_dict_ = (
-                    X[self.variables_].mean() + self.fold * X[self.variables_].std()
+                imputer_dict_ = (
+                    X[variables_].mean() + self.fold * X[variables_].std()
                 ).to_dict()
             elif self.tail == "left":
-                self.imputer_dict_ = (
-                    X[self.variables_].mean() - self.fold * X[self.variables_].std()
+                imputer_dict_ = (
+                    X[variables_].mean() - self.fold * X[variables_].std()
                 ).to_dict()
 
         elif self.imputation_method == "iqr":
-            IQR = X[self.variables_].quantile(0.75) - X[self.variables_].quantile(0.25)
+            IQR = X[variables_].quantile(0.75) - X[variables_].quantile(0.25)
             if self.tail == "right":
-                self.imputer_dict_ = (
-                    X[self.variables_].quantile(0.75) + (IQR * self.fold)
+                imputer_dict_ = (
+                    X[variables_].quantile(0.75) + (IQR * self.fold)
                 ).to_dict()
             elif self.tail == "left":
-                self.imputer_dict_ = (
-                    X[self.variables_].quantile(0.25) - (IQR * self.fold)
+                imputer_dict_ = (
+                    X[variables_].quantile(0.25) - (IQR * self.fold)
                 ).to_dict()
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/mean_median.py
+++ b/feature_engine/imputation/mean_median.py
@@ -127,17 +127,19 @@ class MeanMedianImputer(BaseImputer):
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(X)
+            variables_ = find_numerical_variables(X)
         else:
-            self.variables_ = check_numerical_variables(X, self.variables)
+            variables_ = check_numerical_variables(X, self.variables)
 
         # find imputation parameters: mean or median
         if self.imputation_method == "mean":
-            self.imputer_dict_ = X[self.variables_].mean().to_dict()
+            imputer_dict_ = X[variables_].mean().to_dict()
 
         elif self.imputation_method == "median":
-            self.imputer_dict_ = X[self.variables_].median().to_dict()
+            imputer_dict_ = X[variables_].median().to_dict()
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/mean_median.py
+++ b/feature_engine/imputation/mean_median.py
@@ -138,17 +138,19 @@ class MeanImputer(BaseImputer):
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(X, self.return_empty)
+            variables_ = find_numerical_variables(X, self.return_empty)
         else:
-            self.variables_ = check_numerical_variables(X, self.variables)
+            variables_ = check_numerical_variables(X, self.variables)
 
         # find imputation parameters: mean or median
         if self.imputation_method == "mean":
-            self.imputer_dict_ = X[self.variables_].mean().to_dict()
+            imputer_dict_ = X[variables_].mean().to_dict()
 
         elif self.imputation_method == "median":
-            self.imputer_dict_ = X[self.variables_].median().to_dict()
+            imputer_dict_ = X[variables_].median().to_dict()
 
+        self.variables_ = variables_
+        self.imputer_dict_ = imputer_dict_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/missing_indicator.py
+++ b/feature_engine/imputation/missing_indicator.py
@@ -129,15 +129,16 @@ class AddMissingIndicator(BaseImputer):
 
         # find variables for which indicator should be added
         if self.variables is None:
-            self.variables_ = find_all_variables(X)
+            variables_ = find_all_variables(X)
         else:
-            self.variables_ = check_all_variables(X, self.variables)
+            variables_ = check_all_variables(X, self.variables)
 
         if self.missing_only is True:
-            self.variables_ = [
-                var for var in self.variables_ if X[var].isnull().sum() > 0
+            variables_ = [
+                var for var in variables_ if X[var].isnull().sum() > 0
             ]
 
+        self.variables_ = variables_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/missing_indicator.py
+++ b/feature_engine/imputation/missing_indicator.py
@@ -141,15 +141,14 @@ class MissingIndicator(BaseImputer):
 
         # find variables for which indicator should be added
         if self.variables is None:
-            self.variables_ = find_all_variables(X, self.return_empty)
+            variables_ = find_all_variables(X, self.return_empty)
         else:
-            self.variables_ = check_all_variables(X, self.variables)
+            variables_ = check_all_variables(X, self.variables)
 
         if self.missing_only is True:
-            self.variables_ = [
-                var for var in self.variables_ if X[var].isnull().sum() > 0
-            ]
+            variables_ = [var for var in variables_ if X[var].isnull().sum() > 0]
 
+        self.variables_ = variables_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/random_sample.py
+++ b/feature_engine/imputation/random_sample.py
@@ -184,26 +184,29 @@ class RandomSampleImputer(BaseImputer):
 
         # find variables to impute
         if self.variables is None:
-            self.variables_ = find_all_variables(X)
+            variables_ = find_all_variables(X)
         else:
-            self.variables_ = check_all_variables(X, self.variables)
+            variables_ = check_all_variables(X, self.variables)
 
         # take a copy of the selected variables
-        self.X_ = X[self.variables_].copy()
+        X_ = X[variables_].copy()
 
         # check the variables assigned to the random state
         if self.seed == "observation":
-            self.random_state = _check_variables_input_value(self.random_state)
-            if isinstance(self.random_state, (int, str)):
-                self.random_state = [self.random_state]
-            if self.random_state and any(
-                var for var in self.random_state if var not in X.columns
+            random_state = _check_variables_input_value(self.random_state)
+            if isinstance(random_state, (int, str)):
+                random_state = [random_state]
+            if random_state and any(
+                var for var in random_state if var not in X.columns
             ):
                 raise ValueError(
-                    "There are variables assigned as random state which are not part "
-                    "of the training dataframe."
+                    "One or more of the variables indicated in random_state "
+                    "is not present in the dataframe."
                 )
+            self.random_state = random_state
 
+        self.variables_ = variables_
+        self.X_ = X_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/imputation/random_sample.py
+++ b/feature_engine/imputation/random_sample.py
@@ -198,26 +198,29 @@ class RandomSampleImputer(BaseImputer):
 
         # find variables to impute
         if self.variables is None:
-            self.variables_ = find_all_variables(X, self.return_empty)
+            variables_ = find_all_variables(X, self.return_empty)
         else:
-            self.variables_ = check_all_variables(X, self.variables)
+            variables_ = check_all_variables(X, self.variables)
 
         # take a copy of the selected variables
-        self.X_ = X[self.variables_].copy()
+        X_ = X[variables_].copy()
 
         # check the variables assigned to the random state
         if self.seed == "observation":
-            self.random_state = _check_variables_input_value(self.random_state)
-            if isinstance(self.random_state, (int, str)):
-                self.random_state = [self.random_state]
-            if self.random_state and any(
-                var for var in self.random_state if var not in X.columns
+            random_state = _check_variables_input_value(self.random_state)
+            if isinstance(random_state, (int, str)):
+                random_state = [random_state]
+            if random_state and any(
+                var for var in random_state if var not in X.columns
             ):
                 raise ValueError(
                     "There are variables assigned as random state which are not part "
                     "of the training dataframe."
                 )
+            self.random_state = random_state
 
+        self.variables_ = variables_
+        self.X_ = X_
         self._get_feature_names_in(X)
 
         return self

--- a/feature_engine/scaling/mean_normalization.py
+++ b/feature_engine/scaling/mean_normalization.py
@@ -120,17 +120,23 @@ class MeanNormalizationScaler(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
-        self.mean_ = X[self.variables_].mean().to_dict()
-        self.range_ = (X[self.variables_].max() - X[self.variables_].min()).to_dict()
+        X, variables_ = self._fit_setup(X)
+
+        mean_ = X[variables_].mean().to_dict()
+        range_ = (X[variables_].max() - X[variables_].min()).to_dict()
 
         # check for constant columns
-        constant_columns = [col for col, value in self.range_.items() if value == 0]
+        constant_columns = [col for col, value in range_.items() if value == 0]
         if constant_columns:
             raise ValueError(
                 f"The following variable(s) are constant: {constant_columns}. "
                 "Division by zero is not allowed. Please remove constant columns."
             )
+
+        self.variables_ = variables_
+        self.mean_ = mean_
+        self.range_ = range_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/scaling/mean_normalization.py
+++ b/feature_engine/scaling/mean_normalization.py
@@ -130,17 +130,23 @@ class MeanNormalisationScaler(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
-        self.mean_ = X[self.variables_].mean().to_dict()
-        self.range_ = (X[self.variables_].max() - X[self.variables_].min()).to_dict()
+        X, variables_ = self._fit_setup(X)
+
+        mean_ = X[variables_].mean().to_dict()
+        range_ = (X[variables_].max() - X[variables_].min()).to_dict()
 
         # check for constant columns
-        constant_columns = [col for col, value in self.range_.items() if value == 0]
+        constant_columns = [col for col, value in range_.items() if value == 0]
         if constant_columns:
             raise ValueError(
                 f"The following variable(s) are constant: {constant_columns}. "
                 "Division by zero is not allowed. Please remove constant columns."
             )
+
+        self.variables_ = variables_
+        self.mean_ = mean_
+        self.range_ = range_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/arcsin.py
+++ b/feature_engine/transformation/arcsin.py
@@ -121,7 +121,9 @@ class ArcsinTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         # check if the variables are in the correct range
         if ((X[self.variables_] < 0) | (X[self.variables_] > 1)).any().any():

--- a/feature_engine/transformation/arcsin.py
+++ b/feature_engine/transformation/arcsin.py
@@ -122,15 +122,16 @@ class ArcsinTransformer(BaseNumericalTransformer):
 
         # check input dataframe
         X, variables_ = self._fit_setup(X)
-        self.variables_ = variables_
-        self._get_feature_names_in(X)
 
         # check if the variables are in the correct range
-        if ((X[self.variables_] < 0) | (X[self.variables_] > 1)).any().any():
+        if ((X[variables_] < 0) | (X[variables_] > 1)).any().any():
             raise ValueError(
                 "Some variables contain values outside the possible range 0-1. "
                 "Can't apply the arcsin transformation. "
             )
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/arcsin.py
+++ b/feature_engine/transformation/arcsin.py
@@ -133,14 +133,17 @@ class ArcsinTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         # check if the variables are in the correct range
-        if ((X[self.variables_] < 0) | (X[self.variables_] > 1)).any().any():
+        if ((X[variables_] < 0) | (X[variables_] > 1)).any().any():
             raise ValueError(
                 "Some variables contain values outside the possible range 0-1. "
                 "Can't apply the arcsin transformation. "
             )
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/arcsinh.py
+++ b/feature_engine/transformation/arcsinh.py
@@ -161,7 +161,9 @@ class ArcSinhTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe and find/check numerical variables
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/arcsinh.py
+++ b/feature_engine/transformation/arcsinh.py
@@ -172,7 +172,10 @@ class ArcSinhTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe and find/check numerical variables
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/boxcox.py
+++ b/feature_engine/transformation/boxcox.py
@@ -135,12 +135,16 @@ class BoxCoxTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
-        self.lambda_dict_ = {}
+        lambda_dict_ = {}
 
-        for var in self.variables_:
-            _, self.lambda_dict_[var] = stats.boxcox(X[var])
+        for var in variables_:
+            _, lambda_dict_[var] = stats.boxcox(X[var])
+
+        self.variables_ = variables_
+        self.lambda_dict_ = lambda_dict_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/boxcox.py
+++ b/feature_engine/transformation/boxcox.py
@@ -147,12 +147,16 @@ class BoxCoxTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
-        self.lambda_dict_ = {}
+        lambda_dict_ = {}
 
-        for var in self.variables_:
-            _, self.lambda_dict_[var] = stats.boxcox(X[var])
+        for var in variables_:
+            _, lambda_dict_[var] = stats.boxcox(X[var])
+
+        self.variables_ = variables_
+        self.lambda_dict_ = lambda_dict_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/log.py
+++ b/feature_engine/transformation/log.py
@@ -127,7 +127,6 @@ class LogTransformer(BaseNumericalTransformer):
             It is not needed in this transformer. You can pass y or None.
         """
 
-        # check input dataframe
         X, variables_ = self._fit_setup(X)
         self.variables_ = variables_
         self._get_feature_names_in(X)
@@ -363,13 +362,17 @@ class LogCpTransformer(BaseNumericalTransformer, FitFromDictMixin):
             X, variables_ = self._fit_setup(X)
 
         # calculate C to add to each variable
+        C_: Union[int, float, Dict[Union[str, int], Union[float, int]]]
         if self.C == "auto":
             # we add 0 to positive variables
-            c_dict = {var: 0 for var in variables_ if X[var].min() > 0}
+            c_dict: Dict[Union[str, int], Union[float, int]] = {
+                var: 0.0 for var in variables_ if X[var].min() > 0
+            }
 
             # we add the minimum plus 1 to non-positive variables
             non_positive_vars = [var for var in variables_ if var not in c_dict.keys()]
-            c_dict.update(dict(X[non_positive_vars].min(axis=0).abs() + 1))
+            if non_positive_vars:
+                c_dict.update(dict(X[non_positive_vars].min(axis=0).abs() + 1))
             C_ = c_dict
         else:
             C_ = self.C

--- a/feature_engine/transformation/log.py
+++ b/feature_engine/transformation/log.py
@@ -374,8 +374,13 @@ class LogCpTransformer(BaseNumericalTransformer, FitFromDictMixin):
             if non_positive_vars:
                 c_dict.update(dict(X[non_positive_vars].min(axis=0).abs() + 1))
             C_ = c_dict
-        else:
+        elif isinstance(self.C, (int, float, dict)):
             C_ = self.C
+        else:
+            raise ValueError(
+                f"C can take only 'auto', integers, floats or dicts. "
+                f"Got {self.C} instead."
+            )
 
         self.variables_ = variables_
         self.C_ = C_

--- a/feature_engine/transformation/log.py
+++ b/feature_engine/transformation/log.py
@@ -358,25 +358,25 @@ class LogCpTransformer(BaseNumericalTransformer, FitFromDictMixin):
 
         # check input dataframe
         if isinstance(self.C, dict):
-            X = super()._fit_from_dict(X, self.C)
+            X, variables_ = super()._fit_from_dict(X, self.C)
         else:
             X, variables_ = self._fit_setup(X)
-            self.variables_ = variables_
-            self._get_feature_names_in(X)
-
-        self.C_ = self.C
 
         # calculate C to add to each variable
         if self.C == "auto":
             # we add 0 to positive variables
-            c_dict = {var: 0 for var in self.variables_ if X[var].min() > 0}
+            c_dict = {var: 0 for var in variables_ if X[var].min() > 0}
 
             # we add the minimum plus 1 to non-positive variables
-            non_positive_vars = [
-                var for var in self.variables_ if var not in c_dict.keys()
-            ]
+            non_positive_vars = [var for var in variables_ if var not in c_dict.keys()]
             c_dict.update(dict(X[non_positive_vars].min(axis=0).abs() + 1))
-            self.C_ = c_dict  # type:ignore
+            C_ = c_dict
+        else:
+            C_ = self.C
+
+        self.variables_ = variables_
+        self.C_ = C_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/log.py
+++ b/feature_engine/transformation/log.py
@@ -128,14 +128,15 @@ class LogTransformer(BaseNumericalTransformer):
         """
 
         X, variables_ = self._fit_setup(X)
-        self.variables_ = variables_
-        self._get_feature_names_in(X)
 
         # check contains zero or negative values
-        if (X[self.variables_] <= 0).any().any():
+        if (X[variables_] <= 0).any().any():
             raise ValueError(
                 "Some variables contain zero or negative values, can't apply log"
             )
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/log.py
+++ b/feature_engine/transformation/log.py
@@ -128,7 +128,9 @@ class LogTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         # check contains zero or negative values
         if (X[self.variables_] <= 0).any().any():
@@ -358,7 +360,9 @@ class LogCpTransformer(BaseNumericalTransformer, FitFromDictMixin):
         if isinstance(self.C, dict):
             X = super()._fit_from_dict(X, self.C)
         else:
-            X = super().fit(X)
+            X, variables_ = self._fit_setup(X)
+            self.variables_ = variables_
+            self._get_feature_names_in(X)
 
         self.C_ = self.C
 

--- a/feature_engine/transformation/log.py
+++ b/feature_engine/transformation/log.py
@@ -172,30 +172,32 @@ class LogTransformer(BaseNumericalTransformer, FitFromDictMixin):
 
         # check input dataframe
         if isinstance(self.C, dict):
-            X = super()._fit_from_dict(X, self.C)
+            X, variables_ = super()._fit_from_dict(X, self.C)
         else:
-            X = super().fit(X)
+            X, variables_ = self._fit_setup(X)
 
-        self.C_ = self.C
+        C_ = self.C
 
         # calculate C to add to each variable
         if self.C == "auto":
             # we add 0 to positive variables
-            c_dict = {var: 0 for var in self.variables_ if X[var].min() > 0}
+            c_dict = {var: 0 for var in variables_ if X[var].min() > 0}
 
             # we add the minimum plus 1 to non-positive variables
-            non_positive_vars = [
-                var for var in self.variables_ if var not in c_dict.keys()
-            ]
+            non_positive_vars = [var for var in variables_ if var not in c_dict.keys()]
             c_dict.update(dict(X[non_positive_vars].min(axis=0).abs() + 1))
-            self.C_ = c_dict  # type:ignore
+            C_ = c_dict  # type:ignore
 
         # C=0 is the original LogTransformer contract: no constant is added,
         # so fail fast at fit time exactly as before this class supported C.
-        if self.C_ == 0 and (X[self.variables_] <= 0).any().any():
+        if C_ == 0 and (X[variables_] <= 0).any().any():
             raise ValueError(
                 "Some variables contain zero or negative values, can't apply log"
             )
+
+        self.variables_ = variables_
+        self.C_ = C_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/power.py
+++ b/feature_engine/transformation/power.py
@@ -121,7 +121,9 @@ class PowerTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        super().fit(X)
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/power.py
+++ b/feature_engine/transformation/power.py
@@ -132,7 +132,10 @@ class PowerTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        super().fit(X)
+        X, variables_ = self._fit_setup(X)
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/reciprocal.py
+++ b/feature_engine/transformation/reciprocal.py
@@ -113,15 +113,16 @@ class ReciprocalTransformer(BaseNumericalTransformer):
 
         # check input dataframe
         X, variables_ = self._fit_setup(X)
-        self.variables_ = variables_
-        self._get_feature_names_in(X)
 
         # check if the variables contain the value 0
-        if (X[self.variables_] == 0).any().any():
+        if (X[variables_] == 0).any().any():
             raise ValueError(
                 "Some variables contain the value zero, can't apply reciprocal "
                 "transformation."
             )
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/reciprocal.py
+++ b/feature_engine/transformation/reciprocal.py
@@ -112,7 +112,9 @@ class ReciprocalTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         # check if the variables contain the value 0
         if (X[self.variables_] == 0).any().any():

--- a/feature_engine/transformation/reciprocal.py
+++ b/feature_engine/transformation/reciprocal.py
@@ -124,14 +124,17 @@ class ReciprocalTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
         # check if the variables contain the value 0
-        if (X[self.variables_] == 0).any().any():
+        if (X[variables_] == 0).any().any():
             raise ValueError(
                 "Some variables contain the value zero, can't apply reciprocal "
                 "transformation."
             )
+
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/yeojohnson.py
+++ b/feature_engine/transformation/yeojohnson.py
@@ -128,12 +128,16 @@ class YeoJohnsonTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
-        self.lambda_dict_ = {}
+        lambda_dict_ = {}
 
-        for var in self.variables_:
-            _, self.lambda_dict_[var] = stats.yeojohnson(X[var])
+        for var in variables_:
+            _, lambda_dict_[var] = stats.yeojohnson(X[var])
+
+        self.variables_ = variables_
+        self.lambda_dict_ = lambda_dict_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/feature_engine/transformation/yeojohnson.py
+++ b/feature_engine/transformation/yeojohnson.py
@@ -140,12 +140,16 @@ class YeoJohnsonTransformer(BaseNumericalTransformer):
         """
 
         # check input dataframe
-        X = super().fit(X)
+        X, variables_ = self._fit_setup(X)
 
-        self.lambda_dict_ = {}
+        lambda_dict_ = {}
 
-        for var in self.variables_:
-            _, self.lambda_dict_[var] = stats.yeojohnson(X[var])
+        for var in variables_:
+            _, lambda_dict_[var] = stats.yeojohnson(X[var])
+
+        self.variables_ = variables_
+        self.lambda_dict_ = lambda_dict_
+        self._get_feature_names_in(X)
 
         return self
 

--- a/tests/estimator_checks/non_fitted_error_checks.py
+++ b/tests/estimator_checks/non_fitted_error_checks.py
@@ -89,3 +89,40 @@ def _implements_inverse_transform(estimator):
         # implemented", which is all this check needs to establish.
         return True
     return True
+
+
+def check_raises_non_fitted_error_when_fit_fails(estimator, X, y=None):
+    """
+    Check that if fit() raises partway through (after some trailing-underscore
+    attributes may already have been computed, but before fit has completed),
+    the transformer does not end up looking fitted: transform() must still
+    raise NotFittedError.
+
+    This guards against attributes like `variables_` or `imputer_dict_` being
+    assigned to `self` as soon as they are computed, rather than only once the
+    rest of fit()'s logic has completed successfully. sklearn's own
+    check_estimator suite does not cover this: check_fit_check_is_fitted only
+    tests "never fitted" and "successfully fitted with well-behaved data",
+    never "fit raises on bad input" - that scenario is inherently specific to
+    what makes a given transformer's own fit logic fail.
+
+    Parameters
+    ----------
+    estimator: feature-engine transformer instance.
+
+    X: pandas DataFrame
+        Input designed to make estimator.fit() raise partway through.
+
+    y: pandas Series, default=None
+        Target, if the estimator's fit() requires one.
+    """
+    transformer = clone(estimator)
+
+    with pytest.raises((ValueError, TypeError, KeyError)):
+        if y is not None:
+            transformer.fit(X, y)
+        else:
+            transformer.fit(X)
+
+    with pytest.raises(NotFittedError):
+        transformer.transform(X)

--- a/tests/test_base_transformers/test_base_numerical_transformer.py
+++ b/tests/test_base_transformers/test_base_numerical_transformer.py
@@ -7,8 +7,14 @@ from tests.estimator_checks.non_fitted_error_checks import check_raises_non_fitt
 
 
 class MockClass(BaseNumericalTransformer):
-    def __init__(self):
-        self.variables = None
+    def __init__(self, variables=None):
+        self.variables = variables
+
+    def fit(self, X, y=None):
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
+        return X
 
     def transform(self, X):
         return self._check_transform_input_and_state(X)

--- a/tests/test_base_transformers/test_base_numerical_transformer.py
+++ b/tests/test_base_transformers/test_base_numerical_transformer.py
@@ -11,6 +11,12 @@ class MockClass(BaseNumericalTransformer):
         self.variables = None
         self.return_empty = False
 
+    def fit(self, X):
+        X, variables_ = self._fit_setup(X)
+        self.variables_ = variables_
+        self._get_feature_names_in(X)
+        return X
+
     def transform(self, X):
         return self._check_transform_input_and_state(X)
 

--- a/tests/test_creation/test_check_estimator_creation.py
+++ b/tests/test_creation/test_check_estimator_creation.py
@@ -1,3 +1,6 @@
+from sklearn import clone
+from sklearn.exceptions import NotFittedError
+
 import pandas as pd
 import pytest
 import sklearn
@@ -97,3 +100,24 @@ def test_geo_distance_transformer_in_pipeline():
     Xtp = pipe.fit_transform(X.copy(), y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    estimator = clone(estimator)
+
+    X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+    y = pd.Series([0, 1, 0, 1, 0])
+
+    # If variables are provided, we need to ensure they are in the dataframe
+    # or handle the KeyError.
+    if hasattr(estimator, "variables") and estimator.variables:
+        X = pd.DataFrame(
+            {var: ["a", "b", "c", "a", "b"] for var in estimator.variables}
+        )
+
+    with pytest.raises((ValueError, TypeError, KeyError)):
+        estimator.fit(X, y)
+
+    with pytest.raises(NotFittedError):
+        estimator.transform(X)

--- a/tests/test_creation/test_check_estimator_creation.py
+++ b/tests/test_creation/test_check_estimator_creation.py
@@ -19,10 +19,6 @@ from tests.estimator_checks.estimator_checks import check_feature_engine_estimat
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
-# Estimators for sklearn's check_estimator
-# Note: GeoDistanceFeatures is not included here because it requires 4 specific
-# named coordinate columns, but sklearn's check_estimator generates test data
-# with generic column names (x0, x1, x2) that don't match the required columns.
 _estimators = [
     MathFeatures(variables=["x0", "x1"], func="mean", missing_values="ignore"),
     RelativeFeatures(
@@ -102,19 +98,33 @@ def test_geo_distance_transformer_in_pipeline():
     pd.testing.assert_frame_equal(Xtt, Xtp)
 
 
-@pytest.mark.parametrize("estimator", _estimators)
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        CyclicalFeatures(),
+        MathFeatures(variables=["feature_1", "feature_2"], func=["sum", "mean"]),
+        RelativeFeatures(variables=["feature_1"], reference=["feature_2"], func=["div"]),
+        DecisionTreeFeatures(regression=False),
+        GeoDistanceFeatures(lat1="lat1", lon1="lon1", lat2="lat2", lon2="lon2"),
+    ],
+)
 def test_raises_non_fitted_error_when_error_during_fit(estimator):
     estimator = clone(estimator)
+
 
     X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
     y = pd.Series([0, 1, 0, 1, 0])
 
-    # If variables are provided, we need to ensure they are in the dataframe
-    # or handle the KeyError.
+
     if hasattr(estimator, "variables") and estimator.variables:
-        X = pd.DataFrame(
-            {var: ["a", "b", "c", "a", "b"] for var in estimator.variables}
-        )
+        X = pd.DataFrame({var: ["a", "b", "c", "a", "b"] for var in estimator.variables})
+    elif isinstance(estimator, GeoDistanceFeatures):
+        X = pd.DataFrame({
+            "lat1": ["a", "b"],
+            "lon1": ["c", "d"],
+            "lat2": ["e", "f"],
+            "lon2": ["g", "h"],
+        })
 
     with pytest.raises((ValueError, TypeError, KeyError)):
         estimator.fit(X, y)

--- a/tests/test_creation/test_check_estimator_creation.py
+++ b/tests/test_creation/test_check_estimator_creation.py
@@ -102,22 +102,28 @@ def test_geo_distance_transformer_in_pipeline():
     "estimator",
     [
         CyclicalFeatures(),
-        MathFeatures(variables=["feature_1", "feature_2"], func=["sum", "mean"]),
-        RelativeFeatures(variables=["feature_1"], reference=["feature_2"], func=["div"]),
+        MathFeatures(
+            variables=["feature_1", "feature_2"], func=["sum", "mean"]
+        ),
+        RelativeFeatures(
+            variables=["feature_1"], reference=["feature_2"], func=["div"]
+        ),
         DecisionTreeFeatures(regression=False),
-        GeoDistanceFeatures(lat1="lat1", lon1="lon1", lat2="lat2", lon2="lon2"),
+        GeoDistanceFeatures(
+            lat1="lat1", lon1="lon1", lat2="lat2", lon2="lon2"
+        ),
     ],
 )
 def test_raises_non_fitted_error_when_error_during_fit(estimator):
     estimator = clone(estimator)
 
-
     X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
     y = pd.Series([0, 1, 0, 1, 0])
 
-
     if hasattr(estimator, "variables") and estimator.variables:
-        X = pd.DataFrame({var: ["a", "b", "c", "a", "b"] for var in estimator.variables})
+        X = pd.DataFrame(
+            {var: ["a", "b", "c", "a", "b"] for var in estimator.variables}
+        )
     elif isinstance(estimator, GeoDistanceFeatures):
         X = pd.DataFrame({
             "lat1": ["a", "b"],

--- a/tests/test_creation/test_check_estimator_creation.py
+++ b/tests/test_creation/test_check_estimator_creation.py
@@ -13,6 +13,9 @@ from feature_engine.creation import (
     RelativeFeatures,
 )
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.non_fitted_error_checks import (
+    check_raises_non_fitted_error_when_fit_fails,
+)
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -97,3 +100,38 @@ def test_geo_distance_transformer_in_pipeline():
     Xtp = pipe.fit_transform(X.copy(), y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        CyclicalFeatures(),
+        MathFeatures(variables=["feature_1", "feature_2"], func=["sum", "mean"]),
+        RelativeFeatures(
+            variables=["feature_1"], reference=["feature_2"], func=["div"]
+        ),
+        DecisionTreeFeatures(regression=False),
+        GeoDistanceFeatures(lat1="lat1", lon1="lon1", lat2="lat2", lon2="lon2"),
+    ],
+)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    y = pd.Series([0, 1, 0, 1, 0])
+
+    if isinstance(estimator, GeoDistanceFeatures):
+        # non-numerical coordinate columns: fails after variables_ would have
+        # been set, at the "check coordinate columns are numerical" step.
+        X = pd.DataFrame(
+            {
+                "lat1": ["a", "b"],
+                "lon1": ["c", "d"],
+                "lat2": ["e", "f"],
+                "lon2": ["g", "h"],
+            }
+        )
+        y = pd.Series([0, 1])
+    else:
+        # the named/expected variables aren't in the df (or aren't numerical):
+        # fails at variable selection.
+        X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+
+    check_raises_non_fitted_error_when_fit_fails(estimator, X, y)

--- a/tests/test_discretisation/test_check_estimator_discretisers.py
+++ b/tests/test_discretisation/test_check_estimator_discretisers.py
@@ -1,3 +1,6 @@
+from sklearn import clone
+from sklearn.exceptions import NotFittedError
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -63,3 +66,17 @@ def test_transformers_within_pipeline(transformer):
     Xtp = pipe.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    estimator = clone(estimator)
+
+    X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+    y = pd.Series([0, 1, 0, 1, 0])
+
+    with pytest.raises((ValueError, TypeError, KeyError)):
+        estimator.fit(X, y)
+
+    with pytest.raises(NotFittedError):
+        estimator.transform(X)

--- a/tests/test_discretisation/test_check_estimator_discretisers.py
+++ b/tests/test_discretisation/test_check_estimator_discretisers.py
@@ -14,6 +14,9 @@ from feature_engine.discretisation import (
     GeometricWidthDiscretiser,
 )
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.non_fitted_error_checks import (
+    check_raises_non_fitted_error_when_fit_fails,
+)
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -63,3 +66,13 @@ def test_transformers_within_pipeline(transformer):
     Xtp = pipe.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    # no numerical variables in the df: fails at variable selection, before any
+    # of binner_dict_/scores_dict_/variables_ would be computed.
+    X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+    y = pd.Series([0, 1, 0, 1, 0])
+
+    check_raises_non_fitted_error_when_fit_fails(estimator, X, y)

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -97,4 +97,3 @@ def test_raises_non_fitted_error_when_error_during_fit(estimator):
 
     with pytest.raises(NotFittedError):
         estimator.transform(X)
-        

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -1,4 +1,3 @@
-from numpy import nan
 from sklearn import clone
 from sklearn.exceptions import NotFittedError
 
@@ -98,4 +97,3 @@ def test_raises_non_fitted_error_when_error_during_fit(estimator):
 
     with pytest.raises(NotFittedError):
         estimator.transform(X)
-        

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -1,3 +1,7 @@
+from numpy import nan
+from sklearn import clone
+from sklearn.exceptions import NotFittedError
+
 import pandas as pd
 import pytest
 import sklearn
@@ -69,3 +73,29 @@ def test_transformers_in_pipeline_with_set_output_pandas(transformer):
     Xtp = pipe.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    estimator = clone(estimator)
+
+    if estimator.__class__.__name__ in [
+        "MeanMedianImputer",
+        "EndTailImputer",
+        "ArbitraryNumberImputer",
+    ]:
+        X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+
+    elif estimator.__class__.__name__ == "CategoricalImputer":
+        estimator.set_params(ignore_format=False)
+        X = pd.DataFrame({"num1": [1.0, 2.0, 3.0, 4.0, 5.0]})
+
+    else:
+        X = pd.DataFrame()
+
+    with pytest.raises((ValueError, TypeError)):
+        estimator.fit(X)
+
+    with pytest.raises(NotFittedError):
+        estimator.transform(X)
+        

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -97,3 +97,4 @@ def test_raises_non_fitted_error_when_error_during_fit(estimator):
 
     with pytest.raises(NotFittedError):
         estimator.transform(X)
+        

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -15,6 +15,9 @@ from feature_engine.imputation import (
     RandomSampleImputer,
 )
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.non_fitted_error_checks import (
+    check_raises_non_fitted_error_when_fit_fails,
+)
 
 _estimators = [
     MeanImputer(),
@@ -74,3 +77,27 @@ def test_transformers_in_pipeline_with_set_output_pandas(transformer):
     Xtp = pipe.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    if estimator.__class__.__name__ in ["MeanImputer", "EndTailImputer"]:
+        # no numerical variables in the df: fails at variable selection.
+        X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+    elif estimator.__class__.__name__ == "ArbitraryImputer":
+        X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+    elif estimator.__class__.__name__ == "CategoricalImputer":
+        # equally frequent categories: fails after variables_ would have been
+        # selected, inside the "frequent" imputation logic itself.
+        estimator = estimator.__class__(imputation_method="frequent")
+        X = pd.DataFrame({"cat1": ["a", "a", "b", "b"]})
+    elif estimator.__class__.__name__ == "RandomSampleImputer":
+        # invalid random_state: fails after variables_/X_ would have been set.
+        estimator = RandomSampleImputer(seed="observation", random_state="not_a_col")
+        X = pd.DataFrame({"num1": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    else:
+        # AddMissingIndicator, DropMissingData: no reachable failure point
+        # once variables are selected, so fail at input validation instead.
+        X = pd.DataFrame()
+
+    check_raises_non_fitted_error_when_fit_fails(estimator, X)

--- a/tests/test_scaling/test_mean_normalization.py
+++ b/tests/test_scaling/test_mean_normalization.py
@@ -2,6 +2,7 @@ import re
 
 import pandas as pd
 import pytest
+from sklearn import clone
 from sklearn.exceptions import NotFittedError
 
 from feature_engine.scaling import MeanNormalizationScaler
@@ -126,3 +127,21 @@ def test_constant_columns_error():
     transformer = MeanNormalizationScaler()
     with pytest.raises(ValueError, match=re.escape("Division by zero is not allowed")):
         transformer.fit(df)
+
+
+def test_raises_non_fitted_error_when_error_during_fit():
+    # input test case
+    df = pd.DataFrame(
+        {
+            "var1": [1.0, 2.0, 3.0],
+            "var2": [4.0, 5.0, 3.0],
+            "var3": [7.0, 7.0, 7.0],
+        }
+    )
+
+    transformer = MeanNormalizationScaler()
+    with pytest.raises(ValueError, match=re.escape("Division by zero is not allowed")):
+        transformer.fit(df)
+
+    with pytest.raises(NotFittedError):
+        transformer.transform(df)

--- a/tests/test_scaling/test_mean_normalization.py
+++ b/tests/test_scaling/test_mean_normalization.py
@@ -2,7 +2,6 @@ import re
 
 import pandas as pd
 import pytest
-from sklearn import clone
 from sklearn.exceptions import NotFittedError
 
 from feature_engine.scaling import MeanNormalizationScaler

--- a/tests/test_scaling/test_mean_normalization.py
+++ b/tests/test_scaling/test_mean_normalization.py
@@ -6,6 +6,9 @@ from sklearn.exceptions import NotFittedError
 
 from feature_engine.scaling import MeanNormalisationScaler, MeanNormalizationScaler
 from tests.estimator_checks.fit_functionality_checks import check_return_empty
+from tests.estimator_checks.non_fitted_error_checks import (
+    check_raises_non_fitted_error_when_fit_fails,
+)
 
 DEPRECATION_WARNING = (
     "MeanNormalizationScaler was deprecated in favour of "
@@ -155,6 +158,21 @@ def test_constant_columns_error(transformer_class):
     transformer = make_transformer(transformer_class)
     with pytest.raises(ValueError, match=re.escape("Division by zero is not allowed")):
         transformer.fit(df)
+
+
+def test_raises_non_fitted_error_when_error_during_fit(transformer_class):
+    # constant column: fails after mean_/range_ would have been computed, at
+    # the "check for constant columns" step - real regression guard for the
+    # deferred trailing-underscore attribute assignment.
+    df = pd.DataFrame(
+        {
+            "var1": [1.0, 2.0, 3.0],
+            "var2": [4.0, 5.0, 3.0],
+            "var3": [7.0, 7.0, 7.0],
+        }
+    )
+    transformer = make_transformer(transformer_class)
+    check_raises_non_fitted_error_when_fit_fails(transformer, df)
 
 
 def test_check_return_empty(transformer_class):

--- a/tests/test_transformation/test_check_estimator_transformers.py
+++ b/tests/test_transformation/test_check_estimator_transformers.py
@@ -1,3 +1,6 @@
+from sklearn import clone
+from sklearn.exceptions import NotFittedError
+
 import pandas as pd
 import pytest
 import sklearn
@@ -95,3 +98,25 @@ def test_transformers_in_pipeline_with_set_output_pandas(transformer):
     Xtp = pipe.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    estimator = clone(estimator)
+
+    if estimator.__class__.__name__ == "BoxCoxTransformer":
+        X = pd.DataFrame({"num1": [-1.0, 2.0, 3.0, 4.0, 5.0]})
+    elif estimator.__class__.__name__ == "ArcsinTransformer":
+        X = pd.DataFrame({"num1": [1.1, 2.0, 3.0, 4.0, 5.0]})
+    elif estimator.__class__.__name__ == "LogTransformer":
+        X = pd.DataFrame({"num1": [-1.0, 2.0, 3.0, 4.0, 5.0]})
+    elif estimator.__class__.__name__ == "ReciprocalTransformer":
+        X = pd.DataFrame({"num1": [0.0, 2.0, 3.0, 4.0, 5.0]})
+    else:
+        X = pd.DataFrame()
+
+    with pytest.raises((ValueError, TypeError)):
+        estimator.fit(X)
+
+    with pytest.raises(NotFittedError):
+        estimator.transform(X)

--- a/tests/test_transformation/test_check_estimator_transformers.py
+++ b/tests/test_transformation/test_check_estimator_transformers.py
@@ -16,6 +16,9 @@ from feature_engine.transformation import (
     YeoJohnsonTransformer,
 )
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.non_fitted_error_checks import (
+    check_raises_non_fitted_error_when_fit_fails,
+)
 
 _estimators = [
     BoxCoxTransformer(),
@@ -95,3 +98,30 @@ def test_transformers_in_pipeline_with_set_output_pandas(transformer):
     Xtp = pipe.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(Xtt, Xtp)
+
+
+@pytest.mark.parametrize("estimator", _estimators)
+def test_raises_non_fitted_error_when_error_during_fit(estimator):
+    name = estimator.__class__.__name__
+
+    if name == "BoxCoxTransformer":
+        # non-positive values: boxcox itself raises after variables_ selection.
+        X = pd.DataFrame({"num1": [-1.0, 2.0, 3.0, 4.0, 5.0]})
+    elif name == "LogTransformer":
+        # default C=0: zero/negative values raise after variables_ selection.
+        X = pd.DataFrame({"num1": [-1.0, 2.0, 3.0, 4.0, 5.0]})
+    elif name == "ArcsinTransformer":
+        # values outside 0-1: raises after variables_ selection.
+        X = pd.DataFrame({"num1": [1.1, 2.0, 3.0, 4.0, 5.0]})
+    elif name == "ReciprocalTransformer":
+        # zero values: raises after variables_ selection.
+        X = pd.DataFrame({"num1": [0.0, 2.0, 3.0, 4.0, 5.0]})
+    else:
+        # LogCpTransformer (C="auto" never fails on the values themselves),
+        # ArcSinhTransformer, PowerTransformer, YeoJohnsonTransformer: none of
+        # these validate values beyond being numerical, so there is no
+        # reachable failure point once variables_ would be selected. Fail at
+        # variable selection instead.
+        X = pd.DataFrame({"cat1": ["a", "b", "c", "a", "b"]})
+
+    check_raises_non_fitted_error_when_fit_fails(estimator, X)


### PR DESCRIPTION
## Description

This PR ensures that all trailing underscore attributes (`variables_`, `imputer_dict_`, `binner_dict_`) in imputation and discretisation transformers are only assigned **after all fit logic has successfully completed**, following sklearn convention.

## Problem

Previously, attributes like `variables_` were set early in `fit()`, before the remaining logic ran. If an error occurred midway through fitting, the transformer was left in a **partially fitted state** — meaning `transform()` would not raise `NotFittedError` as expected.

For example:
```python
def fit(self, X, y=None):
    self.variables_ = find_numerical_variables(X)  # ← set too early
    self.imputer_dict_ = X[self.variables_].mean()  # ← if this fails, variables_ already set
```

## Tests

Added `test_raises_non_fitted_error_when_error_during_fit` to `tests/test_imputation/test_check_estimator_imputers.py`, following the same pattern already established in `tests/test_encoding/test_check_estimator_encoders.py`.

### First attempt — 4 test cases failed

When the test was first added, it used a numerical-only DataFrame as the failure trigger for all estimators. This worked for `MeanMedianImputer`, `EndTailImputer`, and `ArbitraryNumberImputer`, but **4 cases did not raise** because `CategoricalImputer(ignore_format=True)`, `AddMissingIndicator`, `RandomSampleImputer`, and `DropMissingData` accept all variable types and fitted successfully on that DataFrame.

<img width="1351" height="268" alt="Screenshot 2026-03-22 000733" src="https://github.com/user-attachments/assets/0ddbb9b6-fbae-49a6-a434-0e30b562f9c9" />

### Fix — different triggers per estimator

The test was updated to use the correct failure trigger per estimator type:

| Estimator | Trigger |
|---|---|
| `MeanMedianImputer`, `EndTailImputer`, `ArbitraryNumberImputer` | Categorical-only df → `find_numerical_variables()` raises `TypeError` |
| `CategoricalImputer` | Reset to `ignore_format=False` + numerical-only df → raises `TypeError` |
| `AddMissingIndicator`, `RandomSampleImputer`, `DropMissingData` | Empty df → `check_X()` raises `ValueError` |

## Type of Change
- [x] Bug fix
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

All the test cases are passing locally
<img width="1378" height="193" alt="Screenshot 2026-03-22 001213" src="https://github.com/user-attachments/assets/e756189b-ccb5-4055-91af-1640ed9aa876" />