### PR TITLE
add return_empty attr to base_numerical.py

### DIFF
--- a/feature_engine/_base_transformers/base_numerical.py
+++ b/feature_engine/_base_transformers/base_numerical.py
@@ -1,4 +1,4 @@
-""" The base transformer provides functionality that is shared by most transformer
+"""The base transformer provides functionality that is shared by most transformer
 classes. Provides the base functionality within the fit() and transform() methods
 shared by most transformers, like checking that input is a df, the size, NA, etc.
 """
@@ -60,7 +60,9 @@ class BaseNumericalTransformer(
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(X, return_empty=self.return_empty)
+            self.variables_ = find_numerical_variables(
+                X, return_empty=self.return_empty
+            )
         else:
             self.variables_ = check_numerical_variables(X, self.variables)
 

--- a/feature_engine/_base_transformers/base_numerical.py
+++ b/feature_engine/_base_transformers/base_numerical.py
@@ -60,7 +60,7 @@ class BaseNumericalTransformer(
 
         # find or check for numerical variables
         if self.variables is None:
-            self.variables_ = find_numerical_variables(X)
+            self.variables_ = find_numerical_variables(X, return_empty=self.return_empty)
         else:
             self.variables_ = check_numerical_variables(X, self.variables)
 

--- a/tests/test_base_transformers/test_base_numerical_transformer.py
+++ b/tests/test_base_transformers/test_base_numerical_transformer.py
@@ -17,7 +17,6 @@ class MockClass(BaseNumericalTransformer):
 
 
 def test_empty_find_numerical_variables(df_vartypes):
-    # without return empty_flag, dfs without numerical variables should raise error 
     transformer = MockClass()
     with pytest.raises(TypeError):
         transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))

--- a/tests/test_base_transformers/test_base_numerical_transformer.py
+++ b/tests/test_base_transformers/test_base_numerical_transformer.py
@@ -15,13 +15,10 @@ class MockClass(BaseNumericalTransformer):
         return self._check_transform_input_and_state(X)
 
 
-
 def test_empty_find_numerical_variables(df_vartypes):
-    # without return empty_flag, dfs without numerical variables should raise error 
     transformer = MockClass()
     with pytest.raises(TypeError):
         transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))
-    # Else, no problem
     transformer = MockClass()
     transformer.return_empty = True
     transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))
@@ -71,5 +68,3 @@ def test_transform_method(df_vartypes, df_na):
 
 def test_raises_non_fitted_error():
     check_raises_non_fitted_error(MockClass())
-
-

--- a/tests/test_base_transformers/test_base_numerical_transformer.py
+++ b/tests/test_base_transformers/test_base_numerical_transformer.py
@@ -9,9 +9,23 @@ from tests.estimator_checks.non_fitted_error_checks import check_raises_non_fitt
 class MockClass(BaseNumericalTransformer):
     def __init__(self):
         self.variables = None
+        self.return_empty = False
 
     def transform(self, X):
         return self._check_transform_input_and_state(X)
+
+
+
+def test_empty_find_numerical_variables(df_vartypes):
+    # without return empty_flag, dfs without numerical variables should raise error 
+    transformer = MockClass()
+    with pytest.raises(TypeError):
+        transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))
+    # Else, no problem
+    transformer = MockClass()
+    transformer.return_empty = True
+    transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))
+    assert transformer.variables_ == []
 
 
 def test_fit_method(df_vartypes, df_na):
@@ -57,3 +71,5 @@ def test_transform_method(df_vartypes, df_na):
 
 def test_raises_non_fitted_error():
     check_raises_non_fitted_error(MockClass())
+
+

--- a/tests/test_base_transformers/test_base_numerical_transformer.py
+++ b/tests/test_base_transformers/test_base_numerical_transformer.py
@@ -20,7 +20,6 @@ def test_empty_find_numerical_variables(df_vartypes):
     transformer = MockClass()
     with pytest.raises(TypeError):
         transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))
-    # Else, no problem
     transformer = MockClass()
     transformer.return_empty = True
     transformer.fit(df_vartypes.drop(columns=["Age", "Marks"]))


### PR DESCRIPTION
* `fit()` from `BaseNumericalTransformer` now uses internal attribute `return_empty` as argument when an explicit list of variables is not defined (i.e `None`)
(This breaks around 150 tests, which are expected to be fixed during the sprint) 
* added a test