### PR TITLE
add return_empty tests via shared estimator_checks

### DIFF
--- a/feature_engine/creation/base_creation.py
+++ b/feature_engine/creation/base_creation.py
@@ -8,7 +8,6 @@ from feature_engine._base_transformers.mixins import GetFeatureNamesOutMixin
 from feature_engine._check_init_parameters.check_init_input_params import (
     _check_param_drop_original,
     _check_param_missing_values,
-    _check_return_empty_is_bool,
 )
 from feature_engine.dataframe_checks import (
     _check_contains_inf,
@@ -30,16 +29,13 @@ class BaseCreation(TransformerMixin, BaseEstimator, GetFeatureNamesOutMixin):
         self,
         missing_values: str = "raise",
         drop_original: bool = False,
-        return_empty: bool = False,
     ) -> None:
 
         _check_param_missing_values(missing_values)
         _check_param_drop_original(drop_original)
-        _check_return_empty_is_bool(return_empty)
 
         self.missing_values = missing_values
         self.drop_original = drop_original
-        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """
@@ -59,9 +55,7 @@ class BaseCreation(TransformerMixin, BaseEstimator, GetFeatureNamesOutMixin):
 
         # check variables are numerical
         if self.variables is None:
-            self.variables_ = find_numerical_variables(
-                X, return_empty=self.return_empty
-            )
+            self.variables_ = find_numerical_variables(X)
         else:
             self.variables_ = check_numerical_variables(X, self.variables)
 

--- a/feature_engine/datetime/datetime.py
+++ b/feature_engine/datetime/datetime.py
@@ -356,6 +356,9 @@ class DatetimeFeatures(TransformerMixin, BaseEstimator, GetFeatureNamesOutMixin)
             if self.missing_values == "raise":
                 _check_contains_na(X, self.variables_)
 
+            if len(self.variables_) == 0:
+                return X
+
             # convert datetime variables
             datetime_df = pd.concat(
                 [

--- a/feature_engine/datetime/datetime_ordinal.py
+++ b/feature_engine/datetime/datetime_ordinal.py
@@ -228,6 +228,9 @@ class DatetimeOrdinal(TransformerMixin, BaseEstimator, GetFeatureNamesOutMixin):
         # reorder variables to match train set
         X = X[self.feature_names_in_]
 
+        if len(self.variables_) == 0:
+            return X
+
         # create a copy(to protect original data)
         X_new = X.copy()
 

--- a/feature_engine/datetime/datetime_subtraction.py
+++ b/feature_engine/datetime/datetime_subtraction.py
@@ -5,6 +5,9 @@ import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
 from sklearn.utils.validation import check_is_fitted
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._check_init_parameters.check_variables import (
     _check_variables_input_value,
 )
@@ -203,9 +206,12 @@ class DatetimeSubtraction(BaseCreation):
                     f"Got {new_variables_names} instead."
                 )
 
-        super().__init__(missing_values, drop_original, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(missing_values, drop_original)
         self.variables = _check_variables_input_value(variables)
         self.reference = _check_variables_input_value(reference)
+        self.return_empty = return_empty
         self.new_variables_names = new_variables_names
         self.output_unit = output_unit
         self.dayfirst = dayfirst

--- a/feature_engine/discretisation/base_discretiser.py
+++ b/feature_engine/discretisation/base_discretiser.py
@@ -4,9 +4,6 @@
 import pandas as pd
 
 from feature_engine._base_transformers.base_numerical import BaseNumericalTransformer
-from feature_engine._check_init_parameters.check_init_input_params import (
-    _check_return_empty_is_bool,
-)
 
 
 class BaseDiscretiser(BaseNumericalTransformer):
@@ -21,7 +18,6 @@ class BaseDiscretiser(BaseNumericalTransformer):
         return_object: bool = False,
         return_boundaries: bool = False,
         precision: int = 3,
-        return_empty: bool = False,
     ) -> None:
 
         if not isinstance(return_object, bool):
@@ -40,12 +36,9 @@ class BaseDiscretiser(BaseNumericalTransformer):
                 "precision must be a positive integer. " f"Got {precision} instead."
             )
 
-        _check_return_empty_is_bool(return_empty)
-
         self.return_object = return_object
         self.return_boundaries = return_boundaries
         self.precision = precision
-        self.return_empty = return_empty
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Sort the variable values into the intervals.

--- a/feature_engine/discretisation/equal_frequency.py
+++ b/feature_engine/discretisation/equal_frequency.py
@@ -5,6 +5,9 @@ from typing import List, Optional, Union
 
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._check_init_parameters.check_variables import (
     _check_variables_input_value,
 )
@@ -145,10 +148,13 @@ class EqualFrequencyDiscretiser(BaseDiscretiser):
         if not isinstance(q, int):
             raise ValueError(f"q must be an integer. Got {q} instead.")
 
-        super().__init__(return_object, return_boundaries, precision, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(return_object, return_boundaries, precision)
 
         self.q = q
         self.variables = _check_variables_input_value(variables)
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """

--- a/feature_engine/discretisation/equal_width.py
+++ b/feature_engine/discretisation/equal_width.py
@@ -5,6 +5,9 @@ from typing import List, Optional, Union
 
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._check_init_parameters.check_variables import (
     _check_variables_input_value,
 )
@@ -153,10 +156,13 @@ class EqualWidthDiscretiser(BaseDiscretiser):
         if not isinstance(bins, int):
             raise ValueError(f"bins must be an integer. Got {bins} instead.")
 
-        super().__init__(return_object, return_boundaries, precision, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(return_object, return_boundaries, precision)
 
         self.bins = bins
         self.variables = _check_variables_input_value(variables)
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """

--- a/feature_engine/discretisation/geometric_width.py
+++ b/feature_engine/discretisation/geometric_width.py
@@ -3,6 +3,9 @@ from typing import List, Optional, Union
 import numpy as np
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._check_init_parameters.check_variables import (
     _check_variables_input_value,
 )
@@ -144,10 +147,13 @@ class GeometricWidthDiscretiser(BaseDiscretiser):
         if not isinstance(bins, int):
             raise ValueError(f"bins must be an integer. Got {bins} instead.")
 
-        super().__init__(return_object, return_boundaries, precision, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(return_object, return_boundaries, precision)
 
         self.bins = bins
         self.variables = _check_variables_input_value(variables)
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """

--- a/feature_engine/encoding/base_encoder.py
+++ b/feature_engine/encoding/base_encoder.py
@@ -75,7 +75,6 @@ class CategoricalInitMixin:
     missing_values=_missing_values_docstring,
     ignore_format=_ignore_format_docstring,
     variables=_variables_categorical_docstring,
-    return_empty=_return_empty_docstring,
 )
 class CategoricalInitMixinNA:
     """Shared initialization parameters across transformers. Sets and checks init
@@ -88,8 +87,6 @@ class CategoricalInitMixinNA:
     {missing_values}
 
     {ignore_format}
-
-    {return_empty}
     """
 
     def __init__(
@@ -97,7 +94,6 @@ class CategoricalInitMixinNA:
         variables: Union[None, int, str, List[Union[str, int]]] = None,
         missing_values: str = "raise",
         ignore_format: bool = False,
-        return_empty: bool = False,
     ) -> None:
 
         if missing_values not in ["raise", "ignore"]:
@@ -112,12 +108,9 @@ class CategoricalInitMixinNA:
                 f"Got {ignore_format} instead."
             )
 
-        _check_return_empty_is_bool(return_empty)
-
         self.variables = _check_variables_input_value(variables)
         self.ignore_format = ignore_format
         self.missing_values = missing_values
-        self.return_empty = return_empty
 
 
 class CategoricalMethodsMixin(TransformerMixin, BaseEstimator, GetFeatureNamesOutMixin):

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -5,6 +5,9 @@ from typing import List, Optional, Union
 
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -172,9 +175,12 @@ class CountFrequencyEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
             )
 
         check_parameter_unseen(unseen, ["ignore", "raise", "encode"])
-        super().__init__(variables, missing_values, ignore_format, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(variables, missing_values, ignore_format)
         self.encoding_method = encoding_method
         self.unseen = unseen
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """

--- a/feature_engine/encoding/decision_tree.py
+++ b/feature_engine/encoding/decision_tree.py
@@ -295,6 +295,14 @@ class DecisionTreeEncoder(CategoricalMethodsMixin, CategoricalInitMixin):
 
         param_grid = self._assign_param_grid()
 
+        # if the list of variables to transform is empty, we
+        # stop the logic.
+        if isinstance(variables_, list) and len(variables_) == 0:
+            self.encoder_dict_ = {}
+            self.variables_ = variables_
+            self._get_feature_names_in(X)
+            return self
+
         encoder = OrdinalEncoder(
             encoding_method=self.encoding_method,
             variables=variables_,

--- a/feature_engine/encoding/mean_encoding.py
+++ b/feature_engine/encoding/mean_encoding.py
@@ -4,6 +4,9 @@ from typing import List, Union
 
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -183,7 +186,9 @@ class MeanEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
         smoothing: Union[int, float, str] = 0.0,
         return_empty: bool = False,
     ) -> None:
-        super().__init__(variables, missing_values, ignore_format, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(variables, missing_values, ignore_format)
         if (
             not isinstance(smoothing, (str, float, int))
             or isinstance(smoothing, str)
@@ -196,6 +201,7 @@ class MeanEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
         self.smoothing = smoothing
         check_parameter_unseen(unseen, ["ignore", "raise", "encode"])
         self.unseen = unseen
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: pd.Series):
         """

--- a/feature_engine/encoding/ordinal.py
+++ b/feature_engine/encoding/ordinal.py
@@ -5,6 +5,9 @@ from typing import List, Optional, Union
 
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -180,9 +183,12 @@ class OrdinalEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
             )
 
         check_parameter_unseen(unseen, ["ignore", "raise", "encode"])
-        super().__init__(variables, missing_values, ignore_format, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(variables, missing_values, ignore_format)
         self.encoding_method = encoding_method
         self.unseen = unseen
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """Learn the numbers to be used to replace the categories in each

--- a/feature_engine/encoding/rare_label.py
+++ b/feature_engine/encoding/rare_label.py
@@ -7,6 +7,9 @@ from typing import List, Optional, Union
 import numpy as np
 import pandas as pd
 
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -174,11 +177,14 @@ class RareLabelEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
                 f"Got {replace_with} instead."
             )
 
-        super().__init__(variables, missing_values, ignore_format, return_empty)
+        _check_return_empty_is_bool(return_empty)
+
+        super().__init__(variables, missing_values, ignore_format)
         self.tol = tol
         self.n_categories = n_categories
         self.max_n_categories = max_n_categories
         self.replace_with = replace_with
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """

--- a/feature_engine/encoding/similarity_encoder.py
+++ b/feature_engine/encoding/similarity_encoder.py
@@ -319,6 +319,9 @@ class StringSimilarityEncoder(CategoricalMethodsMixin, CategoricalInitMixin):
         if self.missing_values == "raise":
             _check_optional_contains_na(X, self.variables_)
 
+        if len(self.variables_) == 0:
+            return X
+
         new_values = []
         for var in self.variables_:
             if self.missing_values == "impute":

--- a/feature_engine/preprocessing/match_categories.py
+++ b/feature_engine/preprocessing/match_categories.py
@@ -4,6 +4,9 @@ from typing import List, Optional, Union
 import pandas as pd
 
 from feature_engine._base_transformers.mixins import GetFeatureNamesOutMixin
+from feature_engine._check_init_parameters.check_init_input_params import (
+    _check_return_empty_is_bool,
+)
 from feature_engine._docstrings.fit_attributes import (
     _feature_names_in_docstring,
     _n_features_in_docstring,
@@ -11,6 +14,7 @@ from feature_engine._docstrings.fit_attributes import (
 )
 from feature_engine._docstrings.init_parameters.all_transformers import (
     _missing_values_docstring,
+    _return_empty_docstring,
     _variables_categorical_docstring,
 )
 from feature_engine._docstrings.init_parameters.encoders import _ignore_format_docstring
@@ -26,6 +30,7 @@ from feature_engine.encoding.base_encoder import (
     ignore_format=_ignore_format_docstring,
     missing_values=_missing_values_docstring,
     variables=_variables_categorical_docstring,
+    return_empty=_return_empty_docstring,
     variables_=_variables_attribute_docstring,
     feature_names_in_=_feature_names_in_docstring,
     n_features_in_=_n_features_in_docstring,
@@ -57,6 +62,8 @@ class MatchCategories(
     {ignore_format}
 
     {missing_values}
+
+    {return_empty}
 
     Attributes
     ----------
@@ -116,9 +123,13 @@ class MatchCategories(
         variables: Union[None, int, str, List[Union[str, int]]] = None,
         ignore_format: bool = False,
         missing_values: str = "raise",
+        return_empty: bool = False,
     ) -> None:
 
+        _check_return_empty_is_bool(return_empty)
+
         super().__init__(variables, missing_values, ignore_format)
+        self.return_empty = return_empty
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
         """

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -288,6 +288,12 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
             else:
                 self.variables_ = check_numerical_variables(X, self.variables)
 
+        if len(self.variables_) == 0:
+            # save input features
+            self.feature_names_in_ = X.columns.tolist()
+            self.n_features_in_ = X.shape[1]
+            return self
+
         self.transformer_.fit(X[self.variables_], y)
 
         if self.transformer_.__class__.__name__ in _SELECTORS:
@@ -338,6 +344,10 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
 
         # reorder df to match train set
         X = X[self.feature_names_in_]
+
+        # nothing to transform, e.g. when return_empty selected no variables
+        if len(self.variables_) == 0:
+            return X
 
         # Transformers that add features: creators
         if self.transformer_.__class__.__name__ in [

--- a/tests/estimator_checks/estimator_checks.py
+++ b/tests/estimator_checks/estimator_checks.py
@@ -6,6 +6,7 @@ from tests.estimator_checks.dataframe_for_checks import test_df
 from tests.estimator_checks.fit_functionality_checks import (
     check_error_if_y_not_passed,
     check_feature_names_in,
+    check_return_empty,
 )
 from tests.estimator_checks.get_feature_names_out_checks import (
     check_get_feature_names_out,
@@ -55,6 +56,8 @@ def check_feature_engine_estimator(estimator, needs_group: bool = False):
 
     - check that users enters permitted values to init parameters `missing_values`.
 
+    - checks correct functionality of parameter `return_empty`.
+
     **Checks based on transformer tags.**
 
     - checks that transformer raises error if y is not passed.
@@ -96,6 +99,9 @@ def check_feature_engine_estimator(estimator, needs_group: bool = False):
 
     if hasattr(estimator, "drop_original"):
         check_drop_original_variables(estimator)
+
+    if "return_empty" in estimator.get_params():
+        check_return_empty(estimator)
 
     return None
 

--- a/tests/estimator_checks/estimator_checks.py
+++ b/tests/estimator_checks/estimator_checks.py
@@ -100,7 +100,7 @@ def check_feature_engine_estimator(estimator, needs_group: bool = False):
     if hasattr(estimator, "drop_original"):
         check_drop_original_variables(estimator)
 
-    if "return_empty" in estimator.get_params():
+    if hasattr(estimator, "return_empty"):
         check_return_empty(estimator)
 
     return None

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -49,9 +49,6 @@ def check_return_empty(estimator):
     this way, since there is always at least one variable of *some* type in a
     non-empty dataframe: the check is skipped for those.
     """
-    if "return_empty" not in estimator.get_params():
-        return
-
     y = pd.Series([0, 1, 0, 1, 0, 1])
     candidate_dfs = [
         pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -53,8 +53,14 @@ def check_return_empty(estimator):
         return
     else:
         df = pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]})
+        variable_tag = "categorical"
 
     y = pd.Series([0, 1, 0, 1, 0, 1])
+    raise_match = f"No {variable_tag} variables found in this dataframe"
+    warn_match = (
+        f"No {variable_tag} variables found in this dataframe. "
+        "Returning an empty list."
+    )
 
     # ignore_format=True makes categorical transformers select all variables
     # regardless of type, which defeats the purpose of this check.
@@ -65,13 +71,13 @@ def check_return_empty(estimator):
     # default: raises an error
     transformer = clone(estimator)
     transformer.set_params(**base_params)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=raise_match):
         transformer.fit(df, y)
 
     # return_empty=True: warns and returns an empty list instead of raising
     transformer = clone(estimator)
     transformer.set_params(**{**base_params, "return_empty": True})
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=warn_match):
         transformer.fit(df, y)
     assert transformer.variables_ == []
 

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -35,6 +35,30 @@ def check_error_if_y_not_passed(estimator):
         estimator.fit(X)
 
 
+# A dataframe with no variables of the given type, keyed by the transformer's
+# `variables` tag (see feature_engine.tags._return_tags and each transformer's
+# _more_tags()). Fitting with variables=None on the matching dataframe is what
+# triggers the "no variables found" path that return_empty controls.
+_NO_VARIABLES_OF_TYPE = {
+    "numerical": pd.DataFrame({"var_cat": ["A", "B", "A", "B", "A", "B"]}),
+    "categorical": pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),
+    "datetime": pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),
+}
+
+# A couple of transformers don't carry the right `variables` tag, for reasons
+# unrelated to return_empty:
+# - LogTransformer's own _more_tags() doesn't set "variables" at all (a
+#   pre-existing gap; it's numerical like its sibling transformers).
+# - DatetimeSubtraction inherits BaseCreation's "skip" tag, which exists so
+#   the *generic* variable-assignment checks leave it alone (it needs
+#   `variables` and `reference` checked together, which those checks don't
+#   support) -- but it does select datetime variables.
+_TAG_OVERRIDE_BY_CLASS_NAME = {
+    "LogTransformer": "numerical",
+    "DatetimeSubtraction": "datetime",
+}
+
+
 def check_return_empty(estimator):
     """
     Only for transformers with the init parameter `return_empty`.
@@ -45,18 +69,19 @@ def check_return_empty(estimator):
     instead assigns an empty list to `variables_`, and raises a `UserWarning`
     instead of an error.
 
-    Transformers that accept every variable type (tagged 'all') cannot be probed
-    this way, since there is always at least one variable of *some* type in a
-    non-empty dataframe: the check is skipped for those.
+    Transformers that accept every variable type (tagged 'all') are skipped:
+    there is always at least one variable of *some* type in a non-empty
+    dataframe, so there is no dataframe that can trigger "no variables found"
+    for them.
     """
+    variables_tag = _TAG_OVERRIDE_BY_CLASS_NAME.get(
+        estimator.__class__.__name__, estimator._more_tags().get("variables")
+    )
+    if variables_tag not in _NO_VARIABLES_OF_TYPE:
+        return
+    no_variables_df = _NO_VARIABLES_OF_TYPE[variables_tag]
+
     y = pd.Series([0, 1, 0, 1, 0, 1])
-    candidate_dfs = [
-        pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),
-        pd.DataFrame({"var_cat": ["A", "B", "A", "B", "A", "B"]}),
-        pd.DataFrame(
-            {"var_date": pd.date_range("2020-01-01", periods=6, freq="D")}
-        ),
-    ]
 
     # ignore_format=True makes categorical transformers select all variables
     # regardless of type, which defeats the purpose of this check.
@@ -67,19 +92,6 @@ def check_return_empty(estimator):
     # way as `variables`, and require both to be None together.
     if "reference" in estimator.get_params():
         base_params["reference"] = None
-
-    no_variables_df = None
-    for df in candidate_dfs:
-        transformer = clone(estimator)
-        transformer.set_params(**base_params)
-        try:
-            transformer.fit(df, y)
-        except TypeError:
-            no_variables_df = df
-            break
-
-    if no_variables_df is None:
-        return
 
     # default: raises an error
     transformer = clone(estimator)

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -35,30 +35,6 @@ def check_error_if_y_not_passed(estimator):
         estimator.fit(X)
 
 
-# A dataframe with no variables of the given type, keyed by the transformer's
-# `variables` tag (see feature_engine.tags._return_tags and each transformer's
-# _more_tags()). Fitting with variables=None on the matching dataframe is what
-# triggers the "no variables found" path that return_empty controls.
-_NO_VARIABLES_OF_TYPE = {
-    "numerical": pd.DataFrame({"var_cat": ["A", "B", "A", "B", "A", "B"]}),
-    "categorical": pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),
-    "datetime": pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),
-}
-
-# A couple of transformers don't carry the right `variables` tag, for reasons
-# unrelated to return_empty:
-# - LogTransformer's own _more_tags() doesn't set "variables" at all (a
-#   pre-existing gap; it's numerical like its sibling transformers).
-# - DatetimeSubtraction inherits BaseCreation's "skip" tag, which exists so
-#   the *generic* variable-assignment checks leave it alone (it needs
-#   `variables` and `reference` checked together, which those checks don't
-#   support) -- but it does select datetime variables.
-_TAG_OVERRIDE_BY_CLASS_NAME = {
-    "LogTransformer": "numerical",
-    "DatetimeSubtraction": "datetime",
-}
-
-
 def check_return_empty(estimator):
     """
     Only for transformers with the init parameter `return_empty`.
@@ -68,18 +44,15 @@ def check_return_empty(estimator):
     raises a `TypeError` by default. When `return_empty` is set to `True`, `fit()`
     instead assigns an empty list to `variables_`, and raises a `UserWarning`
     instead of an error.
-
-    Transformers that accept every variable type (tagged 'all') are skipped:
-    there is always at least one variable of *some* type in a non-empty
-    dataframe, so there is no dataframe that can trigger "no variables found"
-    for them.
     """
-    variables_tag = _TAG_OVERRIDE_BY_CLASS_NAME.get(
-        estimator.__class__.__name__, estimator._more_tags().get("variables")
-    )
-    if variables_tag not in _NO_VARIABLES_OF_TYPE:
+    # dataframe with no variables of the given type
+    variable_tag = estimator._more_tags().get("variables")
+    if variable_tag in ["numerical", "datetime"]:
+        df = pd.DataFrame({"var_cat": ["A", "B", "A", "B", "A", "B"]})
+    elif variable_tag in ["all", "skip"]:
         return
-    no_variables_df = _NO_VARIABLES_OF_TYPE[variables_tag]
+    else:
+        df = pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]})
 
     y = pd.Series([0, 1, 0, 1, 0, 1])
 
@@ -88,16 +61,12 @@ def check_return_empty(estimator):
     base_params = {"variables": None, "return_empty": False}
     if "ignore_format" in estimator.get_params():
         base_params["ignore_format"] = False
-    # transformers like DatetimeSubtraction auto-detect `reference` the same
-    # way as `variables`, and require both to be None together.
-    if "reference" in estimator.get_params():
-        base_params["reference"] = None
 
     # default: raises an error
     transformer = clone(estimator)
     transformer.set_params(**base_params)
     with pytest.raises(TypeError):
-        transformer.fit(no_variables_df, y)
+        transformer.fit(df, y)
 
     # KNOWN BUG: DecisionTreeEncoder builds a nested OrdinalEncoder with
     # `variables=variables_`. When `variables_` is an empty list, that nested
@@ -105,16 +74,16 @@ def check_return_empty(estimator):
     # explicitly passing `variables=[]` by mistake), so fit() raises ValueError
     # instead of completing. This asserts today's actual behaviour so the test
     # documents the bug rather than papering over it.
-    if estimator.__class__.__name__ == "DecisionTreeEncoder":
-        transformer = clone(estimator)
-        transformer.set_params(**{**base_params, "return_empty": True})
-        with pytest.raises(ValueError, match="The list of `variables` is empty"):
-            transformer.fit(no_variables_df, y)
-        return
+    # if estimator.__class__.__name__ == "DecisionTreeEncoder":
+    #     transformer = clone(estimator)
+    #     transformer.set_params(**{**base_params, "return_empty": True})
+    #     with pytest.raises(ValueError, match="The list of `variables` is empty"):
+    #         transformer.fit(df, y)
+    #     return
 
     # return_empty=True: warns and returns an empty list instead of raising
     transformer = clone(estimator)
     transformer.set_params(**{**base_params, "return_empty": True})
     with pytest.warns(UserWarning):
-        transformer.fit(no_variables_df, y)
+        transformer.fit(df, y)
     assert transformer.variables_ == []

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -43,7 +43,7 @@ def check_return_empty(estimator):
     required by the transformer (numerical, categorical or datetime), `fit()`
     raises a `TypeError` by default. When `return_empty` is set to `True`, `fit()`
     instead assigns an empty list to `variables_`, and raises a `UserWarning`
-    instead of an error.
+    instead of an error. Transformer should return the same dataframe in this case.
     """
     # dataframe with no variables of the given type
     variable_tag = estimator._more_tags().get("variables")

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -1,5 +1,6 @@
 """Checks functionality in the fit method shared by all transformers."""
 
+import pandas as pd
 import pytest
 from sklearn import clone
 
@@ -32,3 +33,79 @@ def check_error_if_y_not_passed(estimator):
     estimator = clone(estimator)
     with pytest.raises(TypeError):
         estimator.fit(X)
+
+
+def check_return_empty(estimator):
+    """
+    Only for transformers with the init parameter `return_empty`.
+
+    When `variables` is None and the train set contains no variables of the type
+    required by the transformer (numerical, categorical or datetime), `fit()`
+    raises a `TypeError` by default. When `return_empty` is set to `True`, `fit()`
+    instead assigns an empty list to `variables_`, and raises a `UserWarning`
+    instead of an error.
+
+    Transformers that accept every variable type (tagged 'all') cannot be probed
+    this way, since there is always at least one variable of *some* type in a
+    non-empty dataframe: the check is skipped for those.
+    """
+    if "return_empty" not in estimator.get_params():
+        return
+
+    y = pd.Series([0, 1, 0, 1, 0, 1])
+    candidate_dfs = [
+        pd.DataFrame({"var_num": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}),
+        pd.DataFrame({"var_cat": ["A", "B", "A", "B", "A", "B"]}),
+        pd.DataFrame(
+            {"var_date": pd.date_range("2020-01-01", periods=6, freq="D")}
+        ),
+    ]
+
+    # ignore_format=True makes categorical transformers select all variables
+    # regardless of type, which defeats the purpose of this check.
+    base_params = {"variables": None, "return_empty": False}
+    if "ignore_format" in estimator.get_params():
+        base_params["ignore_format"] = False
+    # transformers like DatetimeSubtraction auto-detect `reference` the same
+    # way as `variables`, and require both to be None together.
+    if "reference" in estimator.get_params():
+        base_params["reference"] = None
+
+    no_variables_df = None
+    for df in candidate_dfs:
+        transformer = clone(estimator)
+        transformer.set_params(**base_params)
+        try:
+            transformer.fit(df, y)
+        except TypeError:
+            no_variables_df = df
+            break
+
+    if no_variables_df is None:
+        return
+
+    # default: raises an error
+    transformer = clone(estimator)
+    transformer.set_params(**base_params)
+    with pytest.raises(TypeError):
+        transformer.fit(no_variables_df, y)
+
+    # KNOWN BUG: DecisionTreeEncoder builds a nested OrdinalEncoder with
+    # `variables=variables_`. When `variables_` is an empty list, that nested
+    # encoder's own constructor rejects it (a guard meant to catch users
+    # explicitly passing `variables=[]` by mistake), so fit() raises ValueError
+    # instead of completing. This asserts today's actual behaviour so the test
+    # documents the bug rather than papering over it.
+    if estimator.__class__.__name__ == "DecisionTreeEncoder":
+        transformer = clone(estimator)
+        transformer.set_params(**{**base_params, "return_empty": True})
+        with pytest.raises(ValueError, match="The list of `variables` is empty"):
+            transformer.fit(no_variables_df, y)
+        return
+
+    # return_empty=True: warns and returns an empty list instead of raising
+    transformer = clone(estimator)
+    transformer.set_params(**{**base_params, "return_empty": True})
+    with pytest.warns(UserWarning):
+        transformer.fit(no_variables_df, y)
+    assert transformer.variables_ == []

--- a/tests/estimator_checks/fit_functionality_checks.py
+++ b/tests/estimator_checks/fit_functionality_checks.py
@@ -68,22 +68,14 @@ def check_return_empty(estimator):
     with pytest.raises(TypeError):
         transformer.fit(df, y)
 
-    # KNOWN BUG: DecisionTreeEncoder builds a nested OrdinalEncoder with
-    # `variables=variables_`. When `variables_` is an empty list, that nested
-    # encoder's own constructor rejects it (a guard meant to catch users
-    # explicitly passing `variables=[]` by mistake), so fit() raises ValueError
-    # instead of completing. This asserts today's actual behaviour so the test
-    # documents the bug rather than papering over it.
-    # if estimator.__class__.__name__ == "DecisionTreeEncoder":
-    #     transformer = clone(estimator)
-    #     transformer.set_params(**{**base_params, "return_empty": True})
-    #     with pytest.raises(ValueError, match="The list of `variables` is empty"):
-    #         transformer.fit(df, y)
-    #     return
-
     # return_empty=True: warns and returns an empty list instead of raising
     transformer = clone(estimator)
     transformer.set_params(**{**base_params, "return_empty": True})
     with pytest.warns(UserWarning):
         transformer.fit(df, y)
     assert transformer.variables_ == []
+
+    # if return_empty=True, transformer should return same df
+    # after transformation
+    dft = transformer.transform(df)
+    pd.testing.assert_frame_equal(dft, df)

--- a/tests/test_creation/test_decision_tree_features.py
+++ b/tests/test_creation/test_decision_tree_features.py
@@ -6,6 +6,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from feature_engine.creation import DecisionTreeFeatures
+from tests.estimator_checks.fit_functionality_checks import check_return_empty
 
 
 @pytest.fixture(scope="module")
@@ -582,3 +583,11 @@ def test_user_enter_param_grid(df_creation, classification_target):
             X_exp[varn] = preds[:, 1]
 
     pd.testing.assert_frame_equal(Xt, X_exp)
+
+
+def test_check_return_empty():
+    # DecisionTreeFeatures is not part of the check_feature_engine_estimator
+    # pipeline (test_check_estimator_creation.py only feeds MathFeatures,
+    # RelativeFeatures and CyclicalFeatures into it), so return_empty is
+    # tested directly here instead.
+    check_return_empty(DecisionTreeFeatures(regression=False))

--- a/tests/test_datetime/test_datetime_ordinal.py
+++ b/tests/test_datetime/test_datetime_ordinal.py
@@ -4,7 +4,6 @@ import pytest
 
 from feature_engine.datetime import DatetimeOrdinal
 
-
 @pytest.fixture(scope="module")
 def df_datetime_ordinal():
     df = pd.DataFrame({
@@ -286,3 +285,8 @@ def test_return_empty():
     with pytest.warns(UserWarning):
         transformer.fit(X)
     assert transformer.variables_ == []
+
+    # if return_empty=True, transformer should return same df
+    # after transformation
+    dft = transformer.transform(X)
+    pd.testing.assert_frame_equal(dft, X)

--- a/tests/test_datetime/test_datetime_ordinal.py
+++ b/tests/test_datetime/test_datetime_ordinal.py
@@ -267,3 +267,22 @@ def test_more_tags_returns_expected_tags():
     transformer = DatetimeOrdinal()
     expected_tags = {"variables": "datetime"}
     assert transformer._more_tags() == expected_tags
+
+
+def test_return_empty():
+    # DatetimeOrdinal.__init__ does not store `self.start_date = start_date`
+    # (only the derived `self.start_date_`), which breaks sklearn's
+    # get_params()/clone() for this transformer. Because of that, it cannot go
+    # through the shared, clone-based check_return_empty check, nor through
+    # check_feature_engine_estimator at all. This test instantiates the
+    # transformer directly instead.
+    X = pd.DataFrame({"var_num": [1.0, 2.0, 3.0]})
+
+    transformer = DatetimeOrdinal(variables=None, return_empty=False)
+    with pytest.raises(TypeError):
+        transformer.fit(X)
+
+    transformer = DatetimeOrdinal(variables=None, return_empty=True)
+    with pytest.warns(UserWarning):
+        transformer.fit(X)
+    assert transformer.variables_ == []

--- a/tests/test_datetime/test_datetime_ordinal.py
+++ b/tests/test_datetime/test_datetime_ordinal.py
@@ -281,11 +281,16 @@ def test_return_empty():
     X = pd.DataFrame({"var_num": [1.0, 2.0, 3.0]})
 
     transformer = DatetimeOrdinal(variables=None, return_empty=False)
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError, match="No datetime variables found in this dataframe"
+    ):
         transformer.fit(X)
 
     transformer = DatetimeOrdinal(variables=None, return_empty=True)
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+        UserWarning,
+        match="No datetime variables found in this dataframe. Returning an empty list.",
+    ):
         transformer.fit(X)
     assert transformer.variables_ == []
 

--- a/tests/test_datetime/test_datetime_ordinal.py
+++ b/tests/test_datetime/test_datetime_ordinal.py
@@ -4,30 +4,35 @@ import pytest
 
 from feature_engine.datetime import DatetimeOrdinal
 
+
 @pytest.fixture(scope="module")
 def df_datetime_ordinal():
-    df = pd.DataFrame({
-        "date_col_1": pd.to_datetime(
-            ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-05"]
-        ),
-        "date_col_2": pd.to_datetime(
-            ["2024-02-10", "2024-02-11", "2024-02-12", "2024-02-13", "2024-02-14"]
-        ),
-        "non_date_col": [1, 2, 3, 4, 5],
-    })
+    df = pd.DataFrame(
+        {
+            "date_col_1": pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-05"]
+            ),
+            "date_col_2": pd.to_datetime(
+                ["2024-02-10", "2024-02-11", "2024-02-12", "2024-02-13", "2024-02-14"]
+            ),
+            "non_date_col": [1, 2, 3, 4, 5],
+        }
+    )
     return df
 
 
 @pytest.fixture(scope="module")
 def df_datetime_ordinal_na():
-    df = pd.DataFrame({
-        "date_col_1": pd.to_datetime(
-            ["2023-01-01", "2023-01-02", None, "2023-01-04", "2023-01-05"]
-        ),
-        "date_col_2": pd.to_datetime(
-            ["2024-02-10", "2024-02-11", "2024-02-12", None, "2024-02-14"]
-        ),
-    })
+    df = pd.DataFrame(
+        {
+            "date_col_1": pd.to_datetime(
+                ["2023-01-01", "2023-01-02", None, "2023-01-04", "2023-01-05"]
+            ),
+            "date_col_2": pd.to_datetime(
+                ["2024-02-10", "2024-02-11", "2024-02-12", None, "2024-02-14"]
+            ),
+        }
+    )
     return df
 
 
@@ -35,11 +40,11 @@ def df_datetime_ordinal_na():
     "variables_param",
     [
         ["date_col_1", "date_col_2"],  # Case 1: 'variables' are specified
-        None,                          # Case 2: 'variables' not specified
+        None,  # Case 2: 'variables' not specified
     ],
     ids=[
         "variables_specified",
-        "variables_auto_find"
+        "variables_auto_find",
     ],  # Optional but recommended for test readability
 )
 def test_datetime_ordinal_feature_creation(df_datetime_ordinal, variables_param):
@@ -110,8 +115,7 @@ def test_datetime_ordinal_with_start_date_datetime_object(df_datetime_ordinal):
 def test_datetime_ordinal_missing_values_raise(df_datetime_ordinal_na):
     transformer = DatetimeOrdinal(missing_values="raise")
     with pytest.raises(
-            ValueError,
-            match="Some of the variables in the dataset contain NaN"
+        ValueError, match="Some of the variables in the dataset contain NaN"
     ):
         transformer.fit(df_datetime_ordinal_na)
 
@@ -148,8 +152,7 @@ def test_datetime_ordinal_missing_values_ignore(df_datetime_ordinal_na):
 
 def test_datetime_ordinal_invalid_start_date():
     with pytest.raises(
-        ValueError,
-        match="start_date could not be converted to datetime"
+        ValueError, match="start_date could not be converted to datetime"
     ):
         DatetimeOrdinal(start_date="not-a-date")
 

--- a/tests/test_datetime/test_datetime_subtraction.py
+++ b/tests/test_datetime/test_datetime_subtraction.py
@@ -6,7 +6,10 @@ from feature_engine.datetime import DatetimeSubtraction
 from tests.estimator_checks.estimator_checks import (
     check_raises_error_when_input_not_a_df,
 )
-from tests.estimator_checks.fit_functionality_checks import check_feature_names_in
+from tests.estimator_checks.fit_functionality_checks import (
+    check_feature_names_in,
+    check_return_empty,
+)
 from tests.estimator_checks.init_params_triggered_functionality_checks import (
     check_drop_original_variables,
 )
@@ -373,3 +376,4 @@ def test_common_tests(estimator):
     check_raises_error_when_input_not_a_df(estimator)
     check_feature_names_in(estimator)
     check_drop_original_variables(estimator)
+    check_return_empty(estimator)

--- a/tests/test_scaling/test_mean_normalization.py
+++ b/tests/test_scaling/test_mean_normalization.py
@@ -130,7 +130,4 @@ def test_constant_columns_error():
 
 
 def test_check_return_empty():
-    # the scaling module has no test_check_estimator_*.py file and is not
-    # part of the check_feature_engine_estimator pipeline, so return_empty is
-    # tested directly here instead.
     check_return_empty(MeanNormalizationScaler())

--- a/tests/test_scaling/test_mean_normalization.py
+++ b/tests/test_scaling/test_mean_normalization.py
@@ -5,6 +5,7 @@ import pytest
 from sklearn.exceptions import NotFittedError
 
 from feature_engine.scaling import MeanNormalizationScaler
+from tests.estimator_checks.fit_functionality_checks import check_return_empty
 
 
 def test_transforming_int_vars():
@@ -126,3 +127,10 @@ def test_constant_columns_error():
     transformer = MeanNormalizationScaler()
     with pytest.raises(ValueError, match=re.escape("Division by zero is not allowed")):
         transformer.fit(df)
+
+
+def test_check_return_empty():
+    # the scaling module has no test_check_estimator_*.py file and is not
+    # part of the check_feature_engine_estimator pipeline, so return_empty is
+    # tested directly here instead.
+    check_return_empty(MeanNormalizationScaler())

--- a/tests/test_wrappers/test_check_estimator_wrappers.py
+++ b/tests/test_wrappers/test_check_estimator_wrappers.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 import sklearn
 from sklearn.impute import SimpleImputer
@@ -56,3 +57,35 @@ def test_raises_error_when_no_transformer_passed():
     # this transformer needs an estimator as an input param.
     with pytest.raises(TypeError):
         SklearnTransformerWrapper()
+
+
+def test_return_empty():
+    # SklearnTransformerWrapper is not part of the check_feature_engine_estimator
+    # pipeline, so return_empty is tested directly here. The shared
+    # check_return_empty helper isn't reused because, unlike feature-engine's own
+    # transformers, this wrapper delegates the actual fitting to the wrapped
+    # sklearn transformer. When the wrapped transformer is e.g. StandardScaler,
+    # fitting it on zero columns raises its own (expected) error -- return_empty
+    # only controls whether *variable selection* raises, not what the wrapped
+    # transformer does afterwards with an empty selection.
+    X = pd.DataFrame({"var_cat": ["A", "B", "A"]})
+
+    transformer = SklearnTransformerWrapper(
+        transformer=StandardScaler(), variables=None, return_empty=False
+    )
+    with pytest.raises(TypeError):
+        transformer.fit(X)
+
+    transformer = SklearnTransformerWrapper(
+        transformer=StandardScaler(), variables=None, return_empty=True
+    )
+    with pytest.raises(ValueError):
+        # the "no numerical variables found" TypeError is bypassed, but
+        # StandardScaler itself cannot be fit on zero columns.
+        transformer.fit(X)
+    assert transformer.variables_ == []
+
+    # when wrapping a transformer that selects all variable types (e.g.
+    # OrdinalEncoder), find_all_variables always finds at least the 1 column
+    # present in a non-empty dataframe, so return_empty can't be exercised
+    # this way; there is no dataframe that reaches the "no variables" branch.

--- a/tests/test_wrappers/test_check_estimator_wrappers.py
+++ b/tests/test_wrappers/test_check_estimator_wrappers.py
@@ -65,13 +65,19 @@ def test_return_empty():
     transformer = SklearnTransformerWrapper(
         transformer=StandardScaler(), variables=None, return_empty=False
     )
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError, match="No numerical variables found in this dataframe"
+    ):
         transformer.fit(X)
 
     transformer = SklearnTransformerWrapper(
         transformer=StandardScaler(), variables=None, return_empty=True
     )
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+        UserWarning,
+        match="No numerical variables found in this dataframe. "
+        "Returning an empty list.",
+    ):
         transformer.fit(X)
     assert transformer.variables_ == []
 

--- a/tests/test_wrappers/test_check_estimator_wrappers.py
+++ b/tests/test_wrappers/test_check_estimator_wrappers.py
@@ -79,11 +79,14 @@ def test_return_empty():
     transformer = SklearnTransformerWrapper(
         transformer=StandardScaler(), variables=None, return_empty=True
     )
-    with pytest.raises(ValueError):
-        # the "no numerical variables found" TypeError is bypassed, but
-        # StandardScaler itself cannot be fit on zero columns.
+    with pytest.warns(UserWarning):
         transformer.fit(X)
     assert transformer.variables_ == []
+
+    # if return_empty=True, transformer should return same df
+    # after transformation
+    dft = transformer.transform(X)
+    pd.testing.assert_frame_equal(dft, X)
 
     # when wrapping a transformer that selects all variable types (e.g.
     # OrdinalEncoder), find_all_variables always finds at least the 1 column

--- a/tests/test_wrappers/test_check_estimator_wrappers.py
+++ b/tests/test_wrappers/test_check_estimator_wrappers.py
@@ -60,14 +60,6 @@ def test_raises_error_when_no_transformer_passed():
 
 
 def test_return_empty():
-    # SklearnTransformerWrapper is not part of the check_feature_engine_estimator
-    # pipeline, so return_empty is tested directly here. The shared
-    # check_return_empty helper isn't reused because, unlike feature-engine's own
-    # transformers, this wrapper delegates the actual fitting to the wrapped
-    # sklearn transformer. When the wrapped transformer is e.g. StandardScaler,
-    # fitting it on zero columns raises its own (expected) error -- return_empty
-    # only controls whether *variable selection* raises, not what the wrapped
-    # transformer does afterwards with an empty selection.
     X = pd.DataFrame({"var_cat": ["A", "B", "A"]})
 
     transformer = SklearnTransformerWrapper(


### PR DESCRIPTION
Adds check_return_empty to fit_functionality_checks.py and wires it into check_feature_engine_estimator, so it runs automatically for every transformer that already goes through that shared pipeline (transformation, discretisation, encoding, imputation, outliers, most of creation, forecasting).

For transformers not fed through check_feature_engine_estimator, tests are added directly in their existing per-class test files, following the file's established conventions: DecisionTreeFeatures, DatetimeSubtraction, MeanNormalizationScaler and SklearnTransformerWrapper.

DatetimeOrdinal needs a clone-free test, since its __init__ never stores self.start_date, which breaks sklearn's get_params()/clone() for this class independently of return_empty.

DecisionTreeEncoder's return_empty=True path is documented as currently raising ValueError (a real bug: it builds a nested OrdinalEncoder(variables=[]) whose constructor rejects the explicit empty list), rather than silently asserting the intended contract.

AddMissingIndicator, DropMissingData and RandomSampleImputer (variables="all") and SklearnTransformerWrapper wrapping an "all-types" transformer are not testable this way: find_all_variables only raises on a zero-column dataframe, which check_X rejects before variable selection ever runs.

- rolled back change in BaseCreation because it exposed unnecessary parameter on classes
- after rollback of BaseCreation, added return_empty specifically to BaseSubstraction
- rolled back change in BaseDiscretiser for similar reason
- after rollback in BaseDiscretiser added the paramter specifically to required discretisers
- rolled back changes in BaseEncoder for similar reason
- after rollback updated necessary encoders
- fixed failing decision tree encoder
- fixed failing encoders on transform

- [ ] tests for get_feature_names_out when return_empty true and no variables of the required type
- [x] can we add error message matching in the test