### PR TITLE
Remove unused statsmodels dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "pandas>=2.2.0",
     "scikit-learn>=1.4.0",
     "scipy>=1.4.1",
-    "statsmodels>=0.11.1",
 ]
 
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy>=1.18.2
 pandas>=2.2.0
 scikit-learn>=1.4.0
 scipy>=1.4.1
-statsmodels>=0.11.1


### PR DESCRIPTION
## Summary

- Remove the unused `statsmodels` dependency from `pyproject.toml`.
- Remove it from `requirements.txt`.

A repository-wide search confirmed that `statsmodels` and its dependency
`patsy` are not imported or referenced elsewhere in the project.

## Testing

Created a clean Conda environment with Python 3.12 and installed the project:

```console
$ python -m pip install -e ".[tests]"
Successfully built feature_engine
Successfully installed feature_engine-1.9.4
```

Confirmed that `statsmodels` was not installed:

```console
$ python -m pip show statsmodels
WARNING: Package(s) not found: statsmodels
```

Ran the full test suite:

```console
$ python -m pytest -q
2006 passed, 61 warnings in 71.16s
```

Related to #935.