### PR TITLE
expand non_fitted_error_checks for methods get_feature_names_out and inverse transform

### DIFF
--- a/tests/estimator_checks/non_fitted_error_checks.py
+++ b/tests/estimator_checks/non_fitted_error_checks.py
@@ -9,18 +9,23 @@ from tests.estimator_checks.dataframe_for_checks import test_df
 
 def check_raises_non_fitted_error(estimator):
     """
-    Check if transformer raises error when transform() or inverse_transform()
-    methods are called before calling fit() method.
+    Check if transformer raises error when transform(), inverse_transform(),
+    get_feature_names_out() or other fit-dependent methods are called before
+    calling fit() method.
 
-    For transform(), and for inverse_transform() when the transformer implements
-    it, the expected error is NotFittedError, provided by sklearn's
-    `check_is_fitted` function.
+    For transform(), get_feature_names_out(), and for inverse_transform() when
+    the transformer implements it, the expected error is NotFittedError,
+    provided by sklearn's `check_is_fitted` function.
 
     A few transformers expose inverse_transform() but do not implement it (for
     example, OneHotEncoder, RareLabelEncoder and StringSimilarityEncoder). Those
     raise NotImplementedError instead, whether or not fit() was called. We assert
     the specific error each transformer is expected to raise, rather than
     accepting either, so that a transformer that stops guarding fit() is caught.
+
+    A few transformers expose extra methods that also require a fitted
+    transformer, for example, transform_x_y() and return_na_data() in
+    DropMissingData. Those are checked too, when present.
     """
     X, y = test_df()
 
@@ -39,6 +44,23 @@ def check_raises_non_fitted_error(estimator):
         transformer = clone(estimator)
         with pytest.raises(expected_error):
             transformer.inverse_transform(X)
+
+    # Test when fit is not called prior to get_feature_names_out.
+    transformer = clone(estimator)
+    with pytest.raises(NotFittedError):
+        transformer.get_feature_names_out()
+
+    # Test when fit is not called prior to transform_x_y.
+    if hasattr(estimator, "transform_x_y"):
+        transformer = clone(estimator)
+        with pytest.raises(NotFittedError):
+            transformer.transform_x_y(X, y)
+
+    # Test when fit is not called prior to return_na_data.
+    if hasattr(estimator, "return_na_data"):
+        transformer = clone(estimator)
+        with pytest.raises(NotFittedError):
+            transformer.return_na_data(X)
 
 
 def _implements_inverse_transform(estimator):


### PR DESCRIPTION
Fixes #420.

`check_raises_non_fitted_error` only verified that `transform()` and `inverse_transform()` raise `NotFittedError` when called before `fit()`. This extends it to the other public methods that also require a fitted transformer:

- `get_feature_names_out()`
- `transform_x_y()` and `return_na_data()` — guarded with `hasattr`, so they are only exercised on the transformers that implement them (e.g. `DropMissingData`), which the issue pointed to specifically.

The docstring is updated to list the methods now covered. All tests pass locally.
