### PR TITLE
Rename ArbitraryNumberImputer to ArbitraryImputer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please share your story by answering 1 quick question
 
 ### Imputation Methods
 * MeanMedianImputer
-* ArbitraryNumberImputer
+* ArbitraryImputer
 * RandomSampleImputer
 * EndTailImputer
 * CategoricalImputer

--- a/docs/api_doc/imputation/ArbitraryImputer.rst
+++ b/docs/api_doc/imputation/ArbitraryImputer.rst
@@ -1,0 +1,6 @@
+ArbitraryImputer
+================
+
+.. autoclass:: feature_engine.imputation.ArbitraryImputer
+    :members:
+

--- a/docs/api_doc/imputation/ArbitraryNumberImputer.rst
+++ b/docs/api_doc/imputation/ArbitraryNumberImputer.rst
@@ -1,6 +1,0 @@
-ArbitraryNumberImputer
-======================
-
-.. autoclass:: feature_engine.imputation.ArbitraryNumberImputer
-    :members:
-

--- a/docs/api_doc/imputation/index.rst
+++ b/docs/api_doc/imputation/index.rst
@@ -13,7 +13,7 @@ The following table summarises each imputer's functionality:
     Transformer                     Numerical variables	  Categorical variables	    Description
 ================================== ===================== ======================= ====================================================================================
 :class:`MeanImputer()`	        √	                 ×	                    Replaces missing values with the mean or median
-:class:`ArbitraryNumberImputer()`	    √	                 ×	                    Replaces missing values with an arbitrary value
+:class:`ArbitraryImputer()`	    √	                 ×	                    Replaces missing values with an arbitrary value
 :class:`EndTailImputer()`	            √	                 ×	                    Replaces missing values with a value at the end of the distribution
 :class:`CategoricalImputer()`           ×	                 √	                    Replaces missing values with the most frequent category or an arbitrary string
 :class:`RandomSampleImputer()`	        √	                 √	                    Replaces missing values with random value extractions from the variable
@@ -28,7 +28,7 @@ Imputers
    :maxdepth: 1
 
    MeanImputer
-   ArbitraryNumberImputer
+   ArbitraryImputer
    EndTailImputer
    CategoricalImputer
    RandomSampleImputer

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,7 +180,7 @@ Missing data imputation consists in replacing missing values in categorical data
 of those nan values or arbitrary data points. Feature-engine supports the following missing data imputation methods:
 
 - :doc:`api_doc/imputation/MeanImputer`: replaces missing data in numerical variables with the mean or median
-- :doc:`api_doc/imputation/ArbitraryNumberImputer`: replaces missing data in numerical variables with an arbitrary number
+- :doc:`api_doc/imputation/ArbitraryImputer`: replaces missing data in numerical variables with an arbitrary number
 - :doc:`api_doc/imputation/EndTailImputer`: replaces missing data in numerical variables with numbers at the distribution tails
 - :doc:`api_doc/imputation/CategoricalImputer`: replaces missing data with an arbitrary string or with the most frequent category
 - :doc:`api_doc/imputation/RandomSampleImputer`: replaces missing data by random sampling observations from the variable

--- a/docs/user_guide/imputation/ArbitraryImputer.rst
+++ b/docs/user_guide/imputation/ArbitraryImputer.rst
@@ -1,20 +1,20 @@
-.. _arbitrary_number_imputer:
+.. _arbitrary_imputer:
 
 .. currentmodule:: feature_engine.imputation
 
-ArbitraryNumberImputer
-======================
+ArbitraryImputer
+================
 
-The :class:`ArbitraryNumberImputer()` replaces missing data with an arbitrary numerical
+The :class:`ArbitraryImputer()` replaces missing data with an arbitrary numerical
 value determined by the user. It works only with numerical variables.
 
-The :class:`ArbitraryNumberImputer()` can find and impute all numerical variables
+The :class:`ArbitraryImputer()` can find and impute all numerical variables
 automatically. Alternatively, you can pass a list of the variables you want to impute
 to the `variables` parameter.
 
 .. attention::
 
-    **New in version 2.0:** When `variables` is `None`, :class:`ArbitraryNumberImputer()` used to
+    **New in version 2.0:** When `variables` is `None`, :class:`ArbitraryImputer()` used to
     raise an error if the dataframe contained no numerical variables. You can now
     set the new parameter `return_empty` to `True` to make the transformer return an
     empty list of variables and skip the imputation instead, leaving the dataframe
@@ -23,6 +23,12 @@ to the `variables` parameter.
     tailored pipeline for each one. `return_empty` will default to `True` from version
     2.1 onwards.
 
+.. note::
+
+    **Renamed in version 2.0:** ``ArbitraryNumberImputer`` was renamed to
+    ``ArbitraryImputer``. The old name is still available for backwards compatibility
+    but will be removed in version 2.1.0.
+
 You can impute all variables with the same number, in which case you need to define
 the variables to impute in the `variables` parameter and the imputation number in
 `arbitrary_number` parameter. For example, you can impute varA and varB with 99
@@ -30,7 +36,7 @@ like this:
 
 .. code-block:: python
 
-    transformer = ArbitraryNumberImputer(
+    transformer = ArbitraryImputer(
             variables = ['varA', 'varB'],
             arbitrary_number = 99
             )
@@ -44,7 +50,7 @@ with 99 like this:
 
 .. code-block:: python
 
-    transformer = ArbitraryNumberImputer(
+    transformer = ArbitraryImputer(
             imputer_dict = {'varA' : 1, 'varB': 99}
             )
 
@@ -64,7 +70,7 @@ First, let's load the data and separate it into train and test:
     from sklearn.datasets import fetch_openml
     from sklearn.model_selection import train_test_split
 
-    from feature_engine.imputation import ArbitraryNumberImputer
+    from feature_engine.imputation import ArbitraryImputer
 
     # Load dataset
     X, y = fetch_openml(
@@ -83,13 +89,13 @@ First, let's load the data and separate it into train and test:
         random_state=0,
     )
 
-Now we set up the :class:`ArbitraryNumberImputer()` to impute 2 variables from the
+Now we set up the :class:`ArbitraryImputer()` to impute 2 variables from the
 dataset with the number -999:
 
 .. code:: python
 
 	# set up the imputer
-	arbitrary_imputer = ArbitraryNumberImputer(
+	arbitrary_imputer = ArbitraryImputer(
             arbitrary_number=-999,
             variables=['LotFrontage', 'MasVnrArea'],
             )

--- a/docs/user_guide/imputation/EndTailImputer.rst
+++ b/docs/user_guide/imputation/EndTailImputer.rst
@@ -17,7 +17,7 @@ the variable distribution.
 .. tip::
 
     The :class:`EndTailImputer()` **"automates"** the work of the
-    :class:`ArbitraryNumberImputer()` by automatically finding "arbitrary values"
+    :class:`ArbitraryImputer()` by automatically finding "arbitrary values"
     far out at the end of the variable distributions.
 
 :class:`EndTailImputer()` works only with numerical variables. You can impute only a

--- a/docs/user_guide/imputation/index.rst
+++ b/docs/user_guide/imputation/index.rst
@@ -102,7 +102,7 @@ Feature-engine's imputers' main characteristics
     Transformer                     Numerical variables	  Categorical variables	    Description
 ================================== ===================== ======================= ====================================================================================
 :class:`MeanImputer()`	        √	                 ×	                    Replaces missing values with the mean or median
-:class:`ArbitraryNumberImputer()`	    √	                 x	                    Replaces missing values with an arbitrary value
+:class:`ArbitraryImputer()`	    √	                 x	                    Replaces missing values with an arbitrary value
 :class:`EndTailImputer()`	            √	                 ×	                    Replaces missing values with a value at the end of the distribution
 :class:`CategoricalImputer()`           ×	                 √	                    Replaces missing values with the most frequent category or an arbitrary string
 :class:`RandomSampleImputer()`	        √	                 √	                    Replaces missing values with random value extractions from the variable
@@ -158,7 +158,7 @@ nan values look like the majority of the observations.
 Some models can be effectively trained with data that has undergone arbitrary number imputation, such as tree-based models,
 kNN, SVM, and ensemble models.
 
-The :class:`ArbitraryNumberImputer()` implements arbitrary number imputation.
+The :class:`ArbitraryImputer()` implements arbitrary number imputation.
 
 End Tail Imputation
 ~~~~~~~~~~~~~~~~~~~
@@ -341,7 +341,7 @@ Imputers
    :maxdepth: 1
 
    MeanImputer
-   ArbitraryNumberImputer
+   ArbitraryImputer
    EndTailImputer
    CategoricalImputer
    RandomSampleImputer

--- a/docs/user_guide/timeseries/forecasting/WindowFeatures.rst
+++ b/docs/user_guide/timeseries/forecasting/WindowFeatures.rst
@@ -404,12 +404,12 @@ Imputing rows with nan
 
 If instead of removing the row with nan in the window features, we want to impute those
 values, we can do so with any of feature-engine's imputers. Here, we will replace nan with
-the arbitrary value -99, using the `ArbitraryNumberImputer` within a pipeline:
+the arbitrary value -99, using the `ArbitraryImputer` within a pipeline:
 
 
 .. code:: python
 
-    from feature_engine.imputation import ArbitraryNumberImputer
+    from feature_engine.imputation import ArbitraryImputer
     from feature_engine.pipeline import Pipeline
 
     win_f = WindowFeatures(
@@ -420,7 +420,7 @@ the arbitrary value -99, using the `ArbitraryNumberImputer` within a pipeline:
 
     pipe = Pipeline([
         ("windows", win_f),
-        ("imputer", ArbitraryNumberImputer(arbitrary_number=-99))
+        ("imputer", ArbitraryImputer(arbitrary_number=-99))
     ])
 
     X_tr = pipe.fit_transform(X, y)

--- a/feature_engine/imputation/__init__.py
+++ b/feature_engine/imputation/__init__.py
@@ -2,7 +2,7 @@
 The module imputation includes classes to perform missing data imputation
 """
 
-from .arbitrary_number import ArbitraryNumberImputer
+from .arbitrary_imputer import ArbitraryNumberImputer, ArbitraryImputer
 from .categorical import CategoricalImputer
 from .drop_missing_data import DropMissingData
 from .end_tail import EndTailImputer
@@ -12,6 +12,7 @@ from .random_sample import RandomSampleImputer
 
 __all__ = [
     "MeanImputer",
+    "ArbitraryImputer",
     "MeanMedianImputer",
     "ArbitraryNumberImputer",
     "CategoricalImputer",

--- a/feature_engine/imputation/arbitrary_imputer.py
+++ b/feature_engine/imputation/arbitrary_imputer.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Union
 
 import pandas as pd
 
+import warnings
+
 from feature_engine._check_init_parameters.check_input_dictionary import (
     _check_numerical_dict,
 )
@@ -47,9 +49,9 @@ from feature_engine.variable_handling import (
     transform=_transform_imputers_docstring,
     fit_transform=_fit_transform_docstring,
 )
-class ArbitraryNumberImputer(BaseImputer):
+class ArbitraryImputer(BaseImputer):
     """
-    The ArbitraryNumberImputer() replaces missing data by an arbitrary
+    The ArbitraryImputer() replaces missing data by an arbitrary
     value determined by the user. It works only with numerical variables.
 
     You can impute all variables with the same number by defining
@@ -57,7 +59,7 @@ class ArbitraryNumberImputer(BaseImputer):
     `arbitrary_number`. Alternatively, you can pass a dictionary with the variable
     names and the numbers to use for their imputation in the `imputer_dict` parameter.
 
-    More details in the :ref:`User Guide <arbitrary_number_imputer>`.
+    More details in the :ref:`User Guide <arbitrary_imputer>`.
 
     Parameters
     ----------
@@ -104,14 +106,14 @@ class ArbitraryNumberImputer(BaseImputer):
 
     >>> import pandas as pd
     >>> import numpy as np
-    >>> from feature_engine.imputation import ArbitraryNumberImputer
+    >>> from feature_engine.imputation import ArbitraryImputer
     >>> X = pd.DataFrame(dict(
     >>>        x1 = [np.nan,1,1,0,np.nan],
     >>>        x2 = ["a", np.nan, "b", np.nan, "a"],
     >>>       ))
-    >>> ani = ArbitraryNumberImputer(arbitrary_number=-999)
-    >>> ani.fit(X)
-    >>> ani.transform(X)
+    >>> ai = ArbitraryImputer(arbitrary_number=-999)
+    >>> ai.fit(X)
+    >>> ai.transform(X)
           x1   x2
     0 -999.0    a
     1    1.0  NaN
@@ -175,3 +177,27 @@ class ArbitraryNumberImputer(BaseImputer):
         self._get_feature_names_in(X)
 
         return self
+
+
+# TODO: remove in version 2.1.0
+class ArbitraryNumberImputer(ArbitraryImputer):
+    def __init__(
+        self,
+        arbitrary_number: Union[int, float] = 999,
+        variables: Union[None, int, str, List[Union[str, int]]] = None,
+        return_empty: bool = False,
+        imputer_dict: Optional[dict] = None,
+    ) -> None:
+        warnings.warn(
+            "ArbitraryNumberImputer was deprecated in favour of ArbitraryImputer in "
+            "version 2.0.0 and will be removed in version 2.1.0. To silence this "
+            "warning, use ArbitraryImputer instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            arbitrary_number=arbitrary_number,
+            variables=variables,
+            return_empty=return_empty,
+            imputer_dict=imputer_dict,
+        )

--- a/tests/check_estimators_with_parametrize_tests.py
+++ b/tests/check_estimators_with_parametrize_tests.py
@@ -26,7 +26,7 @@ from feature_engine.encoding import (
 )
 from feature_engine.imputation import (
     AddMissingIndicator,
-    ArbitraryNumberImputer,
+    ArbitraryImputer,
     CategoricalImputer,
     DropMissingData,
     EndTailImputer,
@@ -88,7 +88,7 @@ def test_sklearn_compatible_creator(estimator, check):
 @parametrize_with_checks(
     [
         MeanImputer(),
-        ArbitraryNumberImputer(),
+        ArbitraryImputer(),
         CategoricalImputer(fill_value=0, ignore_format=True),
         EndTailImputer(),
         AddMissingIndicator(),

--- a/tests/test_imputation/test_arbitrary_imputer.py
+++ b/tests/test_imputation/test_arbitrary_imputer.py
@@ -1,12 +1,12 @@
-import pandas as pd
 import pytest
+import pandas as pd
 
-from feature_engine.imputation import ArbitraryNumberImputer
+from feature_engine.imputation import ArbitraryImputer, ArbitraryNumberImputer
 
 
 def test_impute_with_99_and_automatically_select_variables(df_na):
     # set up the transformer
-    imputer = ArbitraryNumberImputer(arbitrary_number=99, variables=None)
+    imputer = ArbitraryImputer(arbitrary_number=99, variables=None)
     X_transformed = imputer.fit_transform(df_na)
 
     # set up output reference
@@ -33,7 +33,7 @@ def test_impute_with_99_and_automatically_select_variables(df_na):
 
 def test_impute_with_1_and_single_variable_entered_by_user(df_na):
     # set up transformer
-    imputer = ArbitraryNumberImputer(arbitrary_number=-1, variables=["Age"])
+    imputer = ArbitraryImputer(arbitrary_number=-1, variables=["Age"])
     X_transformed = imputer.fit_transform(df_na)
 
     # set up output reference
@@ -56,12 +56,12 @@ def test_impute_with_1_and_single_variable_entered_by_user(df_na):
 
 def test_error_when_arbitrary_number_is_string():
     with pytest.raises(ValueError):
-        ArbitraryNumberImputer(arbitrary_number="arbitrary")
+        ArbitraryImputer(arbitrary_number="arbitrary")
 
 
 def test_dictionary_of_imputation_values(df_na):
     # set up transformer
-    imputer = ArbitraryNumberImputer(imputer_dict={"Age": -42, "Marks": -999})
+    imputer = ArbitraryImputer(imputer_dict={"Age": -42, "Marks": -999})
     X_transformed = imputer.fit_transform(df_na)
 
     # set up expected output
@@ -79,6 +79,14 @@ def test_dictionary_of_imputation_values(df_na):
     pd.testing.assert_frame_equal(X_transformed, X_reference)
 
 
-def imputer_error_when_dictionary_value_is_string():
+def test_imputer_error_when_dictionary_value_is_string():
     with pytest.raises(ValueError):
-        ArbitraryNumberImputer(imputer_dict={"Age": "arbitrary_number"})
+        ArbitraryImputer(imputer_dict={"Age": "arbitrary_number"})
+
+
+def test_arbitrary_number_imputer_is_deprecated():
+    """ArbitraryNumberImputer should emit a FutureWarning and still work."""
+    with pytest.warns(FutureWarning, match="ArbitraryNumberImputer was deprecated"):
+        imputer = ArbitraryNumberImputer(arbitrary_number=99)
+    assert isinstance(imputer, ArbitraryImputer)
+    assert imputer.arbitrary_number == 99

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -7,7 +7,7 @@ from sklearn.utils.fixes import parse_version
 
 from feature_engine.imputation import (
     MissingIndicator,
-    ArbitraryNumberImputer,
+    ArbitraryImputer,
     CategoricalImputer,
     DropMissingData,
     EndTailImputer,
@@ -18,7 +18,7 @@ from tests.estimator_checks.estimator_checks import check_feature_engine_estimat
 
 _estimators = [
     MeanImputer(),
-    ArbitraryNumberImputer(),
+    ArbitraryImputer(),
     CategoricalImputer(fill_value=0, ignore_format=True),
     EndTailImputer(),
     MissingIndicator(),


### PR DESCRIPTION
## What this PR does
This PR renames ArbitraryNumberImputer to ArbitraryImputer while maintaining backward compatibility through a deprecation cycle.

Fixes #971

## Changes
- Renamed ArbitraryNumberImputer to ArbitraryImputer
- Added a deprecated alias with FutureWarning
- Updated package exports
- Updated documentation to use the new transformer name
- Renamed relevant files where required
- Updated all relevant tests to use ArbitraryImputer
- Added/updated tests to verify the deprecated alias and deprecation warnings

## Testing
All updated tests pass successfully.