### PR TITLE
Rename SklearnTransformerWrapper to SklearnWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Please share your story by answering 1 quick question
  * MatchVariables
  
 ### Wrappers:
- * SklearnTransformerWrapper
+ * SklearnWrapper
 
 ## Installation
 

--- a/docs/api_doc/wrappers/Wrapper.rst
+++ b/docs/api_doc/wrappers/Wrapper.rst
@@ -1,6 +1,5 @@
-SklearnTransformerWrapper
-=========================
+SklearnWrapper
+===============
 
-.. autoclass:: feature_engine.wrappers.SklearnTransformerWrapper
+.. autoclass:: feature_engine.wrappers.SklearnWrapper
     :members:
-

--- a/docs/api_doc/wrappers/index.rst
+++ b/docs/api_doc/wrappers/index.rst
@@ -16,7 +16,7 @@ implementation only on a selected subset of features.
 Other wrappers
 ~~~~~~~~~~~~~~
 
-The :class:`SklearnTransformerWrapper()` offers a similar function to the
+The :class:`SklearnWrapper()` offers a similar function to the
 `ColumnTransformer <https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html>`_
 class available in scikit-learn. They differ in the implementation to select the
 variables.

--- a/docs/user_guide/wrappers/Wrapper.rst
+++ b/docs/user_guide/wrappers/Wrapper.rst
@@ -2,20 +2,20 @@
 
 .. currentmodule:: feature_engine.wrappers
 
-SklearnTransformerWrapper
-=========================
+SklearnWrapper
+==============
 
-The :class:`SklearnTransformerWrapper()` applies scikit-learn transformers to a selected
+The :class:`SklearnWrapper()` applies scikit-learn transformers to a selected
 group of variables. It works with transformers like the SimpleImputer, OrdinalEncoder,
 OneHotEncoder, KBinsDiscretizer, all scalers and also transformers for feature selection.
 Other transformers have not been tested, but we think it should work with most of them.
 
-The :class:`SklearnTransformerWrapper()` offers similar functionality to the
+The :class:`SklearnWrapper()` offers similar functionality to the
 `ColumnTransformer <https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html>`_
 class available in scikit-learn. They differ in the implementation to select the
 variables and the output.
 
-The :class:`SklearnTransformerWrapper()` returns a pandas dataframe with the variables
+The :class:`SklearnWrapper()` returns a pandas dataframe with the variables
 in the order of the original data. The
 `ColumnTransformer <https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html>`_
 returns a Numpy array, and the order of the variables may not coincide with that of the
@@ -23,7 +23,7 @@ original dataset.
 
 .. attention::
 
-    **New in version 2.0:** When `variables` is `None`, :class:`SklearnTransformerWrapper()`
+    **New in version 2.0:** When `variables` is `None`, :class:`SklearnWrapper()`
     used to raise an error if the dataframe contained no variables of the relevant
     type. You can now set the new parameter `return_empty` to `True` to make the
     transformer return an empty list of variables and skip the transformation
@@ -31,6 +31,12 @@ original dataset.
     across different datasets or projects, some of which may not contain variables
     of the relevant type, without building a tailored pipeline for each one.
     `return_empty` will default to `True` from version 2.1 onwards.
+
+.. note::
+
+    **Renamed in version 2.0:** ``SklearnTransformerWrapper`` was renamed to
+    ``SklearnWrapper``. The old name is still available for backwards compatibility
+    but will be removed in version 2.1.0.
 
 In the next code snippet we show how to wrap the SimpleImputer from scikit-learn to
 impute only the selected variables. We start with the imports:
@@ -42,7 +48,7 @@ impute only the selected variables. We start with the imports:
     from sklearn.model_selection import train_test_split
     from sklearn.datasets import fetch_openml
     from sklearn.impute import SimpleImputer
-    from feature_engine.wrappers import SklearnTransformerWrapper
+    from feature_engine.wrappers import SklearnWrapper
 
 Next, we load the house prices dataset and split it into a train set and a test set:
 
@@ -66,7 +72,7 @@ Now, we set up the wrapper with the SimpleImputer, and fit it to the train set:
 .. code:: python
 
     # set up the wrapper with the SimpleImputer
-    imputer = SklearnTransformerWrapper(transformer = SimpleImputer(strategy='mean'),
+    imputer = SklearnWrapper(transformer = SimpleImputer(strategy='mean'),
                                         variables = ['LotFrontage', 'MasVnrArea'])
 
     # fit the wrapper + SimpleImputer
@@ -91,7 +97,7 @@ to standardise only the selected variables. We start with the imports:
     from sklearn.model_selection import train_test_split
     from sklearn.datasets import fetch_openml
     from sklearn.preprocessing import StandardScaler
-    from feature_engine.wrappers import SklearnTransformerWrapper
+    from feature_engine.wrappers import SklearnWrapper
 
 Next, we load the house prices dataset and split it into a train set and a test set:
 
@@ -115,7 +121,7 @@ Now, we set up the wrapper with the StandardScaler, and fit it to the train set:
 .. code:: python
 
     # set up the wrapper with the StandardScaler
-    scaler = SklearnTransformerWrapper(transformer = StandardScaler(),
+    scaler = SklearnWrapper(transformer = StandardScaler(),
                                         variables = ['LotFrontage', 'MasVnrArea'])
 
     # fit the wrapper + StandardScaler
@@ -140,7 +146,7 @@ to select only a subset of the variables. We start with the imports:
     from sklearn.model_selection import train_test_split
     from sklearn.datasets import fetch_openml
     from sklearn.feature_selection import f_regression, SelectKBest
-    from feature_engine.wrappers import SklearnTransformerWrapper
+    from feature_engine.wrappers import SklearnWrapper
 
 Next, we load the house prices dataset and split it into a train set and a test set:
 
@@ -170,7 +176,7 @@ Now, we set up the wrapper with the SelectKBest, and fit it to the train set:
 
 .. code:: python
 
-    selector = SklearnTransformerWrapper(
+    selector = SklearnWrapper(
         transformer = SelectKBest(f_regression, k=5),
         variables = cols)
 
@@ -188,7 +194,7 @@ Even though feature-engine has its own implementation of OneHotEncoder, you may 
 to use scikit-learn's transformer in order to access different options,
 such as drop first category.
 In the following example, we show you how to apply scikit-learn's OneHotEncoder to a
-subset of categories using the :class:`SklearnTransformerWrapper()`. We start with the
+subset of categories using the :class:`SklearnWrapper()`. We start with the
 imports and a function to load and clean the Titanic dataset:
 
 .. code:: python
@@ -197,7 +203,7 @@ imports and a function to load and clean the Titanic dataset:
     import numpy as np
     from sklearn.model_selection import train_test_split
     from sklearn.preprocessing import OneHotEncoder
-    from feature_engine.wrappers import SklearnTransformerWrapper
+    from feature_engine.wrappers import SklearnWrapper
 
     # Load dataset
     def load_titanic():
@@ -227,7 +233,7 @@ to transform the train and test sets:
 
 .. code:: python
 
-    ohe = SklearnTransformerWrapper(
+    ohe = SklearnWrapper(
             OneHotEncoder(sparse=False, drop='first'),
             variables = ['pclass','sex'])
 
@@ -254,7 +260,7 @@ The resulting dataframe is:
     147  NaN      0      0     42.4     n        S       0.0       0.0       1.0
 
 
-Let's say you want to use :class:`SklearnTransformerWrapper()` in a more complex
+Let's say you want to use :class:`SklearnWrapper()` in a more complex
 context. As you may note there are `?` signs to denote unknown values. Due to the
 complexity of the transformations needed we'll use a Pipeline to impute missing values,
 encode categorical features and create interactions for specific variables using
@@ -270,7 +276,7 @@ scikit-learn's PolynomialFeatures. We start with the imports:
     from feature_engine.datasets import load_titanic
     from feature_engine.imputation import CategoricalImputer, MeanImputer
     from feature_engine.encoding import OrdinalEncoder
-    from feature_engine.wrappers import SklearnTransformerWrapper
+    from feature_engine.wrappers import SklearnWrapper
 
 Next, we load the Titanic dataset and split it into a train set and a test set:
 
@@ -285,7 +291,7 @@ Next, we load the Titanic dataset and split it into a train set and a test set:
     X_train, X_test, y_train, y_test= train_test_split(X, y, test_size=0.2, random_state=42)
 
 Now, we assemble the pipeline. The last step wraps scikit-learn's PolynomialFeatures with
-:class:`SklearnTransformerWrapper()`, so that it only creates interactions between
+:class:`SklearnWrapper()`, so that it only creates interactions between
 `pclass` and `sex`:
 
 .. code:: python
@@ -294,7 +300,7 @@ Now, we assemble the pipeline. The last step wraps scikit-learn's PolynomialFeat
         ('ci', CategoricalImputer(imputation_method='frequent')),
         ('mmi', MeanImputer(imputation_method='mean')),
         ('od', OrdinalEncoder(encoding_method='arbitrary')),
-        ('pl', SklearnTransformerWrapper(
+        ('pl', SklearnWrapper(
             PolynomialFeatures(interaction_only = True, include_bias=False),
             variables=['pclass','sex']))
     ])
@@ -332,7 +338,7 @@ More details
 ^^^^^^^^^^^^
 
 In the following Jupyter notebooks you can find more details about how to navigate the
-parameters of the :class:`SklearnTransformerWrapper()` and also access the parameters
+parameters of the :class:`SklearnWrapper()` and also access the parameters
 of the scikit-learn transformer wrapped, as well as the output of the transformations.
 
 - `Wrap sklearn categorical encoder <https://nbviewer.org/github/feature-engine/feature-engine-examples/blob/main/wrappers/Sklearn-wrapper-plus-Categorical-Encoding.ipynb>`_

--- a/feature_engine/wrappers/__init__.py
+++ b/feature_engine/wrappers/__init__.py
@@ -3,6 +3,6 @@ The module wrappers includes classes to wrap Scikit-learn transformers so that t
 can be applied to a selected subset of features and return a dataframe.
 """
 
-from .wrappers import SklearnTransformerWrapper
+from .wrappers import SklearnTransformerWrapper, SklearnWrapper
 
-__all__ = ["SklearnTransformerWrapper"]
+__all__ = ["SklearnWrapper", "SklearnTransformerWrapper"]

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -237,7 +237,7 @@ class SklearnWrapper(TransformerMixin, BaseEstimator):
 
         if transformer.__class__.__name__ == "OneHotEncoder":
             msg = (
-                "The SklearnWrapper can only wrap the OneHotEncoder if the "
+                "SklearnWrapper can only wrap OneHotEncoder if the "
                 "sparse is set to False."
             )
             if getattr(transformer, "sparse", False) or getattr(

--- a/feature_engine/wrappers/wrappers.py
+++ b/feature_engine/wrappers/wrappers.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Optional, Union
 
 import pandas as pd
@@ -73,7 +74,7 @@ _INVERSE_TRANSFORM = [
 ]
 
 
-class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
+class SklearnWrapper(TransformerMixin, BaseEstimator):
     """
     Wrapper to apply scikit-learn transformers to a selected group of variables. It
     supports the following transformers:
@@ -159,10 +160,10 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
     --------
 
     >>> import pandas as pd
-    >>> from feature_engine.wrappers import SklearnTransformerWrapper
+    >>> from feature_engine.wrappers import SklearnWrapper
     >>> from sklearn.preprocessing import StandardScaler
     >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
-    >>> skw = SklearnTransformerWrapper(StandardScaler())
+    >>> skw = SklearnWrapper(StandardScaler())
     >>> skw.fit(X)
     >>> skw.transform(X)
       x1        x2        x3
@@ -171,10 +172,10 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
     2  c  1.224745  1.224745
 
     >>> import pandas as pd
-    >>> from feature_engine.wrappers import SklearnTransformerWrapper
+    >>> from feature_engine.wrappers import SklearnWrapper
     >>> from sklearn.preprocessing import OneHotEncoder
     >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
-    >>> skw = SklearnTransformerWrapper(
+    >>> skw = SklearnWrapper(
     >>>     OneHotEncoder(sparse_output = False), variables = "x1")
     >>> skw.fit(X)
     >>> skw.transform(X)
@@ -184,10 +185,10 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
     2   3   6   0.0   0.0   1.0
 
     >>> import pandas as pd
-    >>> from feature_engine.wrappers import SklearnTransformerWrapper
+    >>> from feature_engine.wrappers import SklearnWrapper
     >>> from sklearn.preprocessing import PolynomialFeatures
     >>> X = pd.DataFrame(dict(x1 = ["a","b","c"], x2 = [1,2,3], x3 = [4,5,6]))
-    >>> skw = SklearnTransformerWrapper(PolynomialFeatures(include_bias = False))
+    >>> skw = SklearnWrapper(PolynomialFeatures(include_bias = False))
     >>> skw.fit(X)
     >>> skw.transform(X)
       x1   x2   x3  x2^2  x2 x3  x3^2
@@ -236,7 +237,7 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
 
         if transformer.__class__.__name__ == "OneHotEncoder":
             msg = (
-                "The SklearnTransformerWrapper can only wrap the OneHotEncoder if the "
+                "The SklearnWrapper can only wrap the OneHotEncoder if the "
                 "sparse is set to False."
             )
             if getattr(transformer, "sparse", False) or getattr(
@@ -477,3 +478,25 @@ class SklearnTransformerWrapper(TransformerMixin, BaseEstimator):
 
     def __sklearn_tags__(self):
         return super().__sklearn_tags__()
+
+
+# TODO: remove in version 2.1.0
+class SklearnTransformerWrapper(SklearnWrapper):
+    def __init__(
+        self,
+        transformer,
+        variables: Union[None, int, str, List[Union[str, int]]] = None,
+        return_empty: bool = False,
+    ) -> None:
+        warnings.warn(
+            "SklearnTransformerWrapper was deprecated in favour of SklearnWrapper in "
+            "version 2.0.0 and will be removed in version 2.1.0. To silence this "
+            "warning, use SklearnWrapper instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            transformer=transformer,
+            variables=variables,
+            return_empty=return_empty,
+        )

--- a/tests/check_estimators_with_parametrize_tests.py
+++ b/tests/check_estimators_with_parametrize_tests.py
@@ -63,7 +63,7 @@ from feature_engine.transformation import (
     ReciprocalTransformer,
     YeoJohnsonTransformer,
 )
-from feature_engine.wrappers import SklearnTransformerWrapper
+from feature_engine.wrappers import SklearnWrapper
 
 
 # creation
@@ -183,7 +183,7 @@ def test_sklearn_compatible_selectors(estimator, check):
 
 
 # wrappers
-@parametrize_with_checks([SklearnTransformerWrapper(SimpleImputer())])
+@parametrize_with_checks([SklearnWrapper(SimpleImputer())])
 def test_sklearn_compatible_wrapper(estimator, check):
     check(estimator)
 

--- a/tests/test_wrappers/test_check_estimator_wrappers.py
+++ b/tests/test_wrappers/test_check_estimator_wrappers.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import OrdinalEncoder, StandardScaler
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.fixes import parse_version
 
-from feature_engine.wrappers import SklearnTransformerWrapper
+from feature_engine.wrappers import SklearnWrapper
 from tests.estimator_checks.estimator_checks import (
     check_raises_error_when_input_not_a_df,
 )
@@ -22,21 +22,21 @@ sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 if sklearn_version < parse_version("1.6"):
 
     def test_sklearn_transformer_wrapper():
-        check_estimator(SklearnTransformerWrapper(transformer=SimpleImputer()))
+        check_estimator(SklearnWrapper(transformer=SimpleImputer()))
 
 else:
 
     def test_sklearn_transformer_wrapper():
         check_estimator(
-            estimator=SklearnTransformerWrapper(transformer=SimpleImputer()),
-            expected_failed_checks=SklearnTransformerWrapper(
+            estimator=SklearnWrapper(transformer=SimpleImputer()),
+            expected_failed_checks=SklearnWrapper(
                 transformer=SimpleImputer()
             )._more_tags()["_xfail_checks"],
         )
 
 
 @pytest.mark.parametrize(
-    "estimator", [SklearnTransformerWrapper(transformer=OrdinalEncoder())]
+    "estimator", [SklearnWrapper(transformer=OrdinalEncoder())]
 )
 def test_check_estimator_from_feature_engine(estimator):
     check_raises_non_fitted_error(estimator)
@@ -46,23 +46,23 @@ def test_check_estimator_from_feature_engine(estimator):
 
 def test_check_variables_assignment():
     check_numerical_variables_assignment(
-        SklearnTransformerWrapper(transformer=StandardScaler())
+        SklearnWrapper(transformer=StandardScaler())
     )
     check_all_types_variables_assignment(
-        SklearnTransformerWrapper(transformer=OrdinalEncoder())
+        SklearnWrapper(transformer=OrdinalEncoder())
     )
 
 
 def test_raises_error_when_no_transformer_passed():
     # this transformer needs an estimator as an input param.
     with pytest.raises(TypeError):
-        SklearnTransformerWrapper()
+        SklearnWrapper()
 
 
 def test_return_empty():
     X = pd.DataFrame({"var_cat": ["A", "B", "A"]})
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=StandardScaler(), variables=None, return_empty=False
     )
     with pytest.raises(
@@ -70,7 +70,7 @@ def test_return_empty():
     ):
         transformer.fit(X)
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=StandardScaler(), variables=None, return_empty=True
     )
     with pytest.warns(

--- a/tests/test_wrappers/test_sklearn_wrapper.py
+++ b/tests/test_wrappers/test_sklearn_wrapper.py
@@ -30,7 +30,7 @@ from sklearn.preprocessing import (
     StandardScaler,
 )
 
-from feature_engine.wrappers import SklearnTransformerWrapper
+from feature_engine.wrappers import SklearnTransformerWrapper, SklearnWrapper
 
 
 if skl_version < "1.7.0":
@@ -79,14 +79,14 @@ def _OneHotEncoder(sparse, drop=None, dtype=np.float64) -> OneHotEncoder:
     ],
 )
 def test_permitted_param_transformer(transformer, df_na):
-    tr = SklearnTransformerWrapper(transformer=transformer)
+    tr = SklearnWrapper(transformer=transformer)
     assert tr.transformer == transformer
 
 
 @pytest.mark.parametrize("transformer", [Lasso(), RandomForestClassifier()])
 def test_error_when_transformer_is_estimator(transformer, df_na):
     with pytest.raises(TypeError):
-        SklearnTransformerWrapper(transformer=transformer)
+        SklearnWrapper(transformer=transformer)
 
 
 if skl_version < "1.7.0":
@@ -108,7 +108,7 @@ else:
 )
 def test_error_not_implemented_transformer(transformer, df_na):
     with pytest.raises(NotImplementedError):
-        SklearnTransformerWrapper(transformer=transformer)
+        SklearnWrapper(transformer=transformer)
 
 
 @pytest.mark.parametrize("transformer", _selectors)
@@ -120,7 +120,7 @@ def test_wrap_selectors(transformer):
 
     # prepare selectors
     sel = clone(transformer)
-    sel_wrap = SklearnTransformerWrapper(transformer=transformer)
+    sel_wrap = SklearnWrapper(transformer=transformer)
 
     # Test:
     # When passing variable list
@@ -156,7 +156,7 @@ def test_wrap_transformers(transformer):
 
     # prepare selectors
     tr = clone(transformer)
-    tr_wrap = SklearnTransformerWrapper(transformer=transformer)
+    tr_wrap = SklearnWrapper(transformer=transformer)
 
     # Test:
     # When passing variable list
@@ -188,7 +188,7 @@ def test_wrap_polynomial_features():
 
     # prepare selectors
     tr = PolynomialFeatures()
-    tr_wrap = SklearnTransformerWrapper(transformer=PolynomialFeatures())
+    tr_wrap = SklearnWrapper(transformer=PolynomialFeatures())
 
     # Test:
     # When passing variable list
@@ -219,7 +219,7 @@ def test_wrap_polynomial_features_get_features_name_out():
     X = fetch_california_housing(as_frame=True).frame
 
     varlist = ["MedInc", "HouseAge", "AveRooms", "AveBedrms"]
-    tr_wrap = SklearnTransformerWrapper(
+    tr_wrap = SklearnWrapper(
         transformer=PolynomialFeatures(), variables=varlist
     )
 
@@ -277,7 +277,7 @@ def test_wrap_simple_imputer(df_na):
         if col not in variables_to_impute
     ]
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=SimpleImputer(fill_value=-999, strategy="constant"),
         variables=variables_to_impute,
     )
@@ -304,7 +304,7 @@ def test_sklearn_imputer_object_with_constant(df_na):
         if col not in variables_to_impute
     ]
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=SimpleImputer(fill_value="missing", strategy="constant"),
         variables=variables_to_impute,
     )
@@ -324,7 +324,7 @@ def test_sklearn_imputer_object_with_constant(df_na):
 
 
 def test_sklearn_imputer_allfeatures_with_constant(df_na):
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=SimpleImputer(fill_value="missing", strategy="constant")
     )
 
@@ -343,7 +343,7 @@ def test_sklearn_imputer_allfeatures_with_constant(df_na):
 def test_sklearn_ohe_object_one_feature(df_vartypes):
     variables_to_encode = ["Name"]
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=_OneHotEncoder(sparse=False, dtype=np.int64),
         variables=variables_to_encode,
     )
@@ -384,7 +384,7 @@ def test_sklearn_ohe_object_one_feature(df_vartypes):
 def test_sklearn_ohe_object_many_features(df_vartypes):
     variables_to_encode = ["Name", "City"]
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=_OneHotEncoder(sparse=False, dtype=np.int64),
         variables=variables_to_encode,
     )
@@ -429,7 +429,7 @@ def test_sklearn_ohe_object_many_features(df_vartypes):
 def test_sklearn_ohe_numeric(df_vartypes):
     variables_to_encode = ["Age"]
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=_OneHotEncoder(sparse=False, dtype=np.int64),
         variables=variables_to_encode,
     )
@@ -468,7 +468,7 @@ def test_sklearn_ohe_numeric(df_vartypes):
 
 
 def test_sklearn_ohe_all_features(df_vartypes):
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=_OneHotEncoder(sparse=False, dtype=np.int64)
     )
 
@@ -543,7 +543,7 @@ def test_sklearn_ohe_with_crossvalidation():
         steps=[
             (
                 "encode_cat",
-                SklearnTransformerWrapper(
+                SklearnWrapper(
                     transformer=_OneHotEncoder(drop="first", sparse=False),
                     variables=["AveBedrms_cat"],
                 ),
@@ -560,7 +560,7 @@ def test_sklearn_ohe_with_crossvalidation():
 
 
 def test_wrap_one_hot_encoder_get_features_name_out(df_vartypes):
-    ohe_wrap = SklearnTransformerWrapper(transformer=_OneHotEncoder(sparse=False))
+    ohe_wrap = SklearnWrapper(transformer=_OneHotEncoder(sparse=False))
     ohe_wrap.fit(df_vartypes)
 
     expected_features_all = [
@@ -618,7 +618,7 @@ def test_inverse_transform(transformer):
     X = fetch_california_housing(as_frame=True).frame
     X = X.drop(["Longitude"], axis=1)
 
-    tr_wrap = SklearnTransformerWrapper(transformer=transformer)
+    tr_wrap = SklearnWrapper(transformer=transformer)
 
     # When passing variable list
     varlist = ["MedInc", "HouseAge", "AveRooms", "AveBedrms"]
@@ -650,7 +650,7 @@ def test_error_when_inverse_transform_not_implemented(transformer):
     y = X["MedHouseVal"]
     X = X.drop(["MedHouseVal"], axis=1)
 
-    tr_wrap = SklearnTransformerWrapper(transformer=transformer)
+    tr_wrap = SklearnWrapper(transformer=transformer)
     tr_wrap.fit(X, y)
     X_tr = tr_wrap.transform(X)
 
@@ -664,7 +664,7 @@ def test_error_when_inverse_transform_not_implemented(transformer):
 @pytest.mark.parametrize("transformer", _transformers)
 def test_get_feature_names_out_transformers(varlist, transformer):
     X = fetch_california_housing(as_frame=True).frame
-    tr_wrap = SklearnTransformerWrapper(transformer=transformer, variables=varlist)
+    tr_wrap = SklearnWrapper(transformer=transformer, variables=varlist)
     Xw = tr_wrap.fit_transform(X)
 
     assert Xw.columns.to_list() == tr_wrap.get_feature_names_out()
@@ -679,7 +679,7 @@ def test_get_feature_names_out_selectors(varlist, transformer):
     X = fetch_california_housing(as_frame=True).frame
     y = X["MedHouseVal"]
     X = X.drop(["MedHouseVal"], axis=1)
-    tr_wrap = SklearnTransformerWrapper(transformer=transformer, variables=varlist)
+    tr_wrap = SklearnWrapper(transformer=transformer, variables=varlist)
     Xw = tr_wrap.fit_transform(X, y)
 
     assert Xw.columns.to_list() == tr_wrap.get_feature_names_out()
@@ -691,7 +691,7 @@ def test_get_feature_names_out_selectors(varlist, transformer):
 )
 def test_get_feature_names_out_polynomialfeatures(varlist):
     X = fetch_california_housing(as_frame=True).frame
-    tr_wrap = SklearnTransformerWrapper(
+    tr_wrap = SklearnWrapper(
         transformer=PolynomialFeatures(), variables=varlist
     )
     Xw = tr_wrap.fit_transform(X)
@@ -721,7 +721,7 @@ def test_get_feature_names_out_polynomialfeatures(varlist):
 
 @pytest.mark.parametrize("varlist", [["Name", "City"], None])
 def test_get_feature_names_out_ohe(varlist, df_vartypes):
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         transformer=_OneHotEncoder(sparse=False, dtype=np.int64),
         variables=varlist,
     )
@@ -750,7 +750,7 @@ def test_function_transformer_works_with_categoricals():
 
     X_expected = pd.DataFrame({"col1": [1.0, 2.0, 3.0], "col2": ["a", "b", "c"]})
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         FunctionTransformer(lambda x: x.astype(np.float64)), variables=["col1"]
     )
 
@@ -764,10 +764,18 @@ def test_function_transformer_works_with_numericals():
 
     X_expected = pd.DataFrame({"col1": [2, 3, 4], "col2": ["a", "b", "c"]})
 
-    transformer = SklearnTransformerWrapper(
+    transformer = SklearnWrapper(
         FunctionTransformer(lambda x: x + 1), variables=["col1"]
     )
 
     X_tf = transformer.fit_transform(X)
 
     pd.testing.assert_frame_equal(X_expected, X_tf)
+
+
+def test_sklearn_transformer_wrapper_is_deprecated():
+    """SklearnTransformerWrapper should emit a FutureWarning and still work."""
+    with pytest.warns(FutureWarning, match="SklearnTransformerWrapper was deprecated"):
+        transformer = SklearnTransformerWrapper(transformer=StandardScaler())
+    assert isinstance(transformer, SklearnWrapper)
+    assert isinstance(transformer.transformer, StandardScaler)


### PR DESCRIPTION
## Summary

- Renames `SklearnTransformerWrapper` to `SklearnWrapper` for a shorter name.
- The old class name is kept as a deprecated alias (`FutureWarning` on instantiation), to be removed in 2.1.0, following the same pattern used in the recent `MeanImputer`, `MissingIndicator`, `Winsoriser`, `MeanNormalisationScaler`, `LogTransformer` and `ArbitraryImputer` renames.
- The `feature_engine.wrappers` package/module names are unchanged.
- Updates API docs, user guide, README, docstrings, and tests to reference the new name.

## Test plan

- [x] `pytest tests/` (2073 passed)
- [x] `flake8 feature_engine tests`
- [x] `mypy feature_engine/wrappers`
- [x] `sphinx-build -W -b html docs <out>` (clean build, 0 warnings)
