### PR TITLE
Rename SelectByTargetMeanPerformance to SelectByTargetEncoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Please share your story by answering 1 quick question
  * SmartCorrelationSelection
  * ShuffleFeaturesSelector
  * SelectBySingleFeaturePerformance
- * SelectByTargetMeanPerformance
+ * SelectByTargetEncoding
  * RecursiveFeatureElimination
  * RecursiveFeatureAddition
  * DropHighPSIFeatures

--- a/docs/api_doc/selection/SelectByTargetEncoding.rst
+++ b/docs/api_doc/selection/SelectByTargetEncoding.rst
@@ -1,0 +1,7 @@
+SelectByTargetEncoding
+======================
+
+
+.. autoclass:: feature_engine.selection.SelectByTargetEncoding
+    :members:
+

--- a/docs/api_doc/selection/SelectByTargetMeanPerformance.rst
+++ b/docs/api_doc/selection/SelectByTargetMeanPerformance.rst
@@ -1,7 +1,0 @@
-SelectByTargetMeanPerformance
-=============================
-
-
-.. autoclass:: feature_engine.selection.SelectByTargetMeanPerformance
-    :members:
-

--- a/docs/api_doc/selection/index.rst
+++ b/docs/api_doc/selection/index.rst
@@ -59,7 +59,7 @@ Alternative feature selection methods
     Transformer                                Categorical variables   Allows NA	    Description
 ============================================ ======================= ============= ====================================================================================
 :class:`SelectByShuffling()`	                ×	                      ×	            Selects features if shuffling their values causes a drop in model performance
-:class:`SelectByTargetMeanPerformance()`        √                         ×             Using the target mean as performance proxy, selects high performing features
+:class:`SelectByTargetEncoding()`            √                       ×             Using the target mean as performance proxy, selects high performing features
 :class:`ProbeFeatureSelection()`                ×                         ×             Selects features whose importance is greater than those of random variables
 ============================================ ======================= ============= ====================================================================================
 
@@ -79,7 +79,7 @@ Alternative feature selection methods
    DropHighPSIFeatures
    SelectByInformationValue
    SelectByShuffling
-   SelectByTargetMeanPerformance
+   SelectByTargetEncoding
    ProbeFeatureSelection
    MRMR
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -290,7 +290,7 @@ existing in other libraries like scikit-learn and MLXtend, with additional metho
 - :doc:`api_doc/selection/SelectByInformationValue`: selects features based on their information value
 - :doc:`api_doc/selection/SelectByShuffling`: selects features by evaluating model performance after feature shuffling
 - :doc:`api_doc/selection/SelectBySingleFeaturePerformance`: selects features based on single feature model performance
-- :doc:`api_doc/selection/SelectByTargetMeanPerformance`: selects features based on target mean encoding
+- :doc:`api_doc/selection/SelectByTargetEncoding`: selects features based on target mean encoding
 - :doc:`api_doc/selection/RecursiveFeatureElimination`: selects features recursively, by evaluating model performance
 - :doc:`api_doc/selection/RecursiveFeatureAddition`: selects features recursively, by evaluating model performance
 - :doc:`api_doc/selection/ProbeFeatureSelection`: selects features with greater importance than those of random variables

--- a/docs/user_guide/selection/SelectByTargetEncoding.rst
+++ b/docs/user_guide/selection/SelectByTargetEncoding.rst
@@ -2,19 +2,25 @@
 
 .. currentmodule:: feature_engine.selection
 
-SelectByTargetMeanPerformance
-=============================
+SelectByTargetEncoding
+======================
 
-:class:`SelectByTargetMeanPerformance()` selects features based on a performance metric,
+:class:`SelectByTargetEncoding()` selects features based on a performance metric,
 like ROC-AUC or accuracy for classification, or mean squared error and R-squared
 for regression.
+
+.. note::
+
+    **Renamed in version 2.0:** ``SelectByTargetMeanPerformance`` was renamed to
+    ``SelectByTargetEncoding``. The old name is still available for backwards
+    compatibility but will be removed in version 2.1.0.
 
 Performance metrics are obtained by comparing a prediction with the real value of the
 target. The closer the values of the prediction to the real target, the better the value
 of the performance metric. Typically, these predictions are obtained from machine learning
 models.
 
-:class:`SelectByTargetMeanPerformance()` uses a very simple method to obtain "predictions".
+:class:`SelectByTargetEncoding()` uses a very simple method to obtain "predictions".
 It returns the mean target value per category or per interval if the variable is continuous.
 With this "prediction", it determines the value of a performance metric of choice for each
 feature, by comparing the values of the "predictions" with that of the target.
@@ -39,7 +45,7 @@ The method has also some limitations. First, the selection of the number of inte
 as well as the threshold is arbitrary. And also, rare categories and very skewed
 variables will raise errors when NAN are accidentally introduced during the evaluation.
 
-:class:`SelectByTargetMeanPerformance()` works with cross-validation. It uses the k-1
+:class:`SelectByTargetEncoding()` works with cross-validation. It uses the k-1
 folds to define the numerical intervals and learn the mean target value per category or
 interval. Then, it uses the remaining fold to evaluate the performance of the
 feature: that is, in the last fold it sorts numerical variables into the bins, replaces
@@ -50,7 +56,7 @@ each feature.
 Important
 ---------
 
-:class:`SelectByTargetMeanPerformance()` automatically identifies numerical and
+:class:`SelectByTargetEncoding()` automatically identifies numerical and
 categorical variables. It will select as categorical variables, those cast as object
 or categorical, and as numerical variables those of type numeric. Therefore, make sure
 that your variables are of the correct data type.
@@ -113,7 +119,7 @@ Let's import the required libraries and classes:
 
     from feature_engine.datasets import load_titanic
     from feature_engine.encoding import RareLabelEncoder
-    from feature_engine.selection import SelectByTargetMeanPerformance
+    from feature_engine.selection import SelectByTargetEncoding
 
 Next, we load the Titanic dataset and prepare it for the demo:
 
@@ -167,14 +173,14 @@ We see the sizes of the datasets below:
 
     ((1178, 8), (131, 8))
 
-Now, we set up :class:`SelectByTargetMeanPerformance()`. We will examine the roc-auc
+Now, we set up :class:`SelectByTargetEncoding()`. We will examine the roc-auc
 using 3 fold cross-validation. We will separate numerical variables into equal-frequency
 intervals. And we will retain those variables where the roc-auc is bigger than the mean
 ROC-AUC of all features (default functionality).
 
 .. code:: python
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=None,
         scoring="roc_auc",
         threshold=None,

--- a/docs/user_guide/selection/index.rst
+++ b/docs/user_guide/selection/index.rst
@@ -112,11 +112,11 @@ Alternative feature selection methods
     Transformer                                Categorical variables   Allows NA	    Description
 ============================================ ======================= ============= ====================================================================================
 :class:`SelectByShuffling()`	                ×	                      ×	            Selects features if shuffling their values causes a drop in model performance
-:class:`SelectByTargetMeanPerformance()`        √                         ×             Using the target mean as performance proxy, selects high performing features
+:class:`SelectByTargetEncoding()`            √                       ×             Using the target mean as performance proxy, selects high performing features
 :class:`ProbeFeatureSelection()`                ×                         ×             Selects features whose importance is greater than those of random variables
 ============================================ ======================= ============= ====================================================================================
 
-The :class:`SelectByTargetMeanPerformance()` uses the target mean value as proxy for prediction,
+The :class:`SelectByTargetEncoding()` uses the target mean value as proxy for prediction,
 replacing categories or variable intervals by these values and then determining a performance metric.
 Thus, it is suitable for both categorical and numerical variables. In its current implementation,
 it does not support missing data.
@@ -144,7 +144,7 @@ Click below to find more details on how to use each one of the transformers.
    RecursiveFeatureElimination
    RecursiveFeatureAddition
    SelectByShuffling
-   SelectByTargetMeanPerformance
+   SelectByTargetEncoding
    DropHighPSIFeatures
    SelectByInformationValue
    ProbeFeatureSelection

--- a/feature_engine/selection/__init__.py
+++ b/feature_engine/selection/__init__.py
@@ -13,7 +13,7 @@ from .recursive_feature_elimination import RecursiveFeatureElimination
 from .shuffle_features import SelectByShuffling
 from .single_feature_performance import SelectBySingleFeaturePerformance
 from .smart_correlation_selection import SmartCorrelatedSelection
-from .target_mean_selection import SelectByTargetMeanPerformance
+from .target_mean_selection import SelectByTargetEncoding, SelectByTargetMeanPerformance
 from .mrmr import MRMR
 
 __all__ = [
@@ -27,6 +27,7 @@ __all__ = [
     "SelectBySingleFeaturePerformance",
     "RecursiveFeatureAddition",
     "RecursiveFeatureElimination",
+    "SelectByTargetEncoding",
     "SelectByTargetMeanPerformance",
     "SelectByInformationValue",
     "ProbeFeatureSelection",

--- a/feature_engine/selection/target_mean_selection.py
+++ b/feature_engine/selection/target_mean_selection.py
@@ -1,3 +1,4 @@
+import warnings
 from types import GeneratorType
 from typing import List, Union
 
@@ -58,22 +59,22 @@ Variables = Union[None, int, str, List[Union[str, int]]]
     fit_transform=_fit_transform_docstring,
     get_support=_get_support_docstring,
 )
-class SelectByTargetMeanPerformance(BaseSelector):
+class SelectByTargetEncoding(BaseSelector):
     """
-    SelectByTargetMeanPerformance() uses the mean value of the target per category or
+    SelectByTargetEncoding() uses the mean value of the target per category or
     per interval (if the variable is numerical), as proxy for target estimation. With
     this proxy, the selector determines the performance of each feature based on a
     metric of choice, and then selects the features based on this performance value.
 
-    SelectByTargetMeanPerformance() can evaluate numerical and categorical variables,
+    SelectByTargetEncoding() can evaluate numerical and categorical variables,
     without much prior manipulation. In other words, you don't need to encode the
     categorical variables or transform the numerical variables to assess their
     importance if you use this transformer.
 
-    SelectByTargetMeanPerformance() requires that the dataset is complete, without
+    SelectByTargetEncoding() requires that the dataset is complete, without
     missing data.
 
-    SelectByTargetMeanPerformance() determines the performance of each variable with
+    SelectByTargetEncoding() determines the performance of each variable with
     cross-validation. More specifically:
 
     For each categorical variable:
@@ -181,13 +182,13 @@ class SelectByTargetMeanPerformance(BaseSelector):
     --------
 
     >>> from sklearn.ensemble import RandomForestClassifier
-    >>> from feature_engine.selection import SelectByTargetMeanPerformance
+    >>> from feature_engine.selection import SelectByTargetEncoding
     >>> X = pd.DataFrame(dict(x1 = [1000,2000,1000,1000,2000,3000],
     >>>                     x2 = [1,1,1,0,0,0],
     >>>                     x3 = [1,2,1,1,0,1],
     >>>                     x4 = [1,1,1,1,1,1]))
     >>> y = pd.Series([1,0,0,1,1,0])
-    >>> tmp = SelectByTargetMeanPerformance(bins = 3, cv=2,scoring='accuracy')
+    >>> tmp = SelectByTargetEncoding(bins = 3, cv=2,scoring='accuracy')
     >>> tmp.fit_transform(X, y)
         x2  x3  x4
     0   1   1   1
@@ -202,7 +203,7 @@ class SelectByTargetMeanPerformance(BaseSelector):
     >>> X = pd.DataFrame(dict(x1 = ["a","b","a","a","b","b"],
     >>>             x2 = ["a","a","a","b","b","b"]))
     >>> y = pd.Series([1,0,0,1,1,0])
-    >>> tmp = SelectByTargetMeanPerformance(bins = 3, cv=2,scoring='accuracy')
+    >>> tmp = SelectByTargetEncoding(bins = 3, cv=2,scoring='accuracy')
     >>> tmp.fit_transform(X, y)
       x2
     0  a
@@ -356,3 +357,37 @@ class SelectByTargetMeanPerformance(BaseSelector):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         return tags
+
+
+# TODO: remove in version 2.1.0
+class SelectByTargetMeanPerformance(SelectByTargetEncoding):
+    def __init__(
+        self,
+        variables: Variables = None,
+        bins: int = 5,
+        strategy: str = "equal_width",
+        scoring: str = "roc_auc",
+        cv=3,
+        groups=None,
+        threshold: Union[int, float, None] = None,
+        regression: bool = False,
+        confirm_variables: bool = False,
+    ):
+        warnings.warn(
+            "SelectByTargetMeanPerformance was deprecated in favour of "
+            "SelectByTargetEncoding in version 2.0.0 and will be removed in version "
+            "2.1.0. To silence this warning, use SelectByTargetEncoding instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            variables=variables,
+            bins=bins,
+            strategy=strategy,
+            scoring=scoring,
+            cv=cv,
+            groups=groups,
+            threshold=threshold,
+            regression=regression,
+            confirm_variables=confirm_variables,
+        )

--- a/tests/check_estimators_with_parametrize_tests.py
+++ b/tests/check_estimators_with_parametrize_tests.py
@@ -47,7 +47,7 @@ from feature_engine.selection import (
     SelectByInformationValue,
     SelectByShuffling,
     SelectBySingleFeaturePerformance,
-    SelectByTargetMeanPerformance,
+    SelectByTargetEncoding,
     SmartCorrelatedSelection,
 )
 from feature_engine.timeseries.forecasting import (
@@ -172,7 +172,7 @@ def test_sklearn_compatible_transformer(estimator, check):
             scoring="accuracy",
             threshold=-100,
         ),
-        SelectByTargetMeanPerformance(scoring="roc_auc", bins=3, regression=False),
+        SelectByTargetEncoding(scoring="roc_auc", bins=3, regression=False),
         SelectByInformationValue(),
         MRMR(),
         ProbeFeatureSelection(estimator=LogisticRegression()),

--- a/tests/parametrize_with_checks_selection_v16.py
+++ b/tests/parametrize_with_checks_selection_v16.py
@@ -20,7 +20,7 @@ from feature_engine.selection import (
     SelectByInformationValue,
     SelectByShuffling,
     SelectBySingleFeaturePerformance,
-    SelectByTargetMeanPerformance,
+    SelectByTargetEncoding,
     SmartCorrelatedSelection,
 )
 
@@ -33,7 +33,7 @@ dcf = DropCorrelatedFeatures()
 dpsi = DropHighPSIFeatures(bins=5)
 sms = SmartCorrelatedSelection()
 sbs = SelectByShuffling(estimator=_logreg, scoring="accuracy")
-sbtm = SelectByTargetMeanPerformance(bins=3, regression=True, scoring="r2")
+sbtm = SelectByTargetEncoding(bins=3, regression=True, scoring="r2")
 sbsfp = SelectBySingleFeaturePerformance(estimator=_logreg, scoring="accuracy")
 rfa = RecursiveFeatureAddition(estimator=_logreg, scoring="accuracy")
 rfe = RecursiveFeatureElimination(estimator=_logreg, scoring="accuracy", threshold=-100)
@@ -49,7 +49,7 @@ EXPECTED_FAILED_CHECKS = {
     "DropHighPSIFeatures": dpsi._more_tags()["_xfail_checks"],
     "SmartCorrelatedSelection": sms._more_tags()["_xfail_checks"],
     "SelectByShuffling": sbs._more_tags()["_xfail_checks"],
-    "SelectByTargetMeanPerformance": sbtm._more_tags()["_xfail_checks"],
+    "SelectByTargetEncoding": sbtm._more_tags()["_xfail_checks"],
     "SelectBySingleFeaturePerformance": sbsfp._more_tags()["_xfail_checks"],
     "RecursiveFeatureAddition": rfa._more_tags()["_xfail_checks"],
     "RecursiveFeatureElimination": rfe._more_tags()["_xfail_checks"],

--- a/tests/test_selection/test_check_estimator_selectors.py
+++ b/tests/test_selection/test_check_estimator_selectors.py
@@ -19,6 +19,7 @@ from feature_engine.selection import (
     SelectByInformationValue,
     SelectByShuffling,
     SelectBySingleFeaturePerformance,
+    SelectByTargetEncoding,
     SelectByTargetMeanPerformance,
     SmartCorrelatedSelection,
 )
@@ -40,6 +41,7 @@ _estimators = [
     DropHighPSIFeatures(bins=5),
     SmartCorrelatedSelection(),
     SelectByShuffling(estimator=_logreg, scoring="accuracy"),
+    SelectByTargetEncoding(bins=3, regression=False),
     SelectByTargetMeanPerformance(bins=3, regression=False),
     SelectBySingleFeaturePerformance(estimator=_logreg, scoring="accuracy"),
     RecursiveFeatureAddition(estimator=_logreg, scoring="accuracy"),
@@ -63,6 +65,7 @@ _univariate_estimators = [
     DropFeatures(features_to_drop=["var_1"]),
     DropConstantFeatures(missing_values="ignore"),
     DropHighPSIFeatures(bins=5),
+    SelectByTargetEncoding(bins=3, regression=False, threshold=0),
     SelectByTargetMeanPerformance(bins=3, regression=False, threshold=0),
     SelectBySingleFeaturePerformance(
         estimator=_logreg,
@@ -94,6 +97,7 @@ else:
     @pytest.mark.parametrize("estimator", _estimators)
     def test_check_estimator_from_sklearn(estimator):
         if estimator.__class__.__name__ not in [
+            "SelectByTargetEncoding",
             "SelectByTargetMeanPerformance",
             "SelectByInformationValue",
         ]:

--- a/tests/test_selection/test_target_mean_selection.py
+++ b/tests/test_selection/test_target_mean_selection.py
@@ -3,7 +3,10 @@ import pytest
 
 from sklearn.model_selection import StratifiedKFold, GroupKFold
 
-from feature_engine.selection import SelectByTargetMeanPerformance
+from feature_engine.selection import (
+    SelectByTargetEncoding,
+    SelectByTargetMeanPerformance,
+)
 
 
 def df_classification():
@@ -53,7 +56,7 @@ def test_classification():
 
     X, y = df_classification()
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=None,
         scoring="accuracy",
         threshold=None,
@@ -79,7 +82,7 @@ def test_classification():
     assert sel.feature_performance_ == performance_dict
     pd.testing.assert_frame_equal(sel.transform(X), Xtransformed)
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=["cat_var_A", "cat_var_B", "num_var_A", "num_var_B"],
         scoring="roc_auc",
         threshold=0.9,
@@ -110,7 +113,7 @@ def test_regression():
 
     X, y = df_regression()
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=None,
         bins=2,
         scoring="r2",
@@ -137,7 +140,7 @@ def test_regression():
 
     X, y = df_regression()
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=["cat_var_A", "cat_var_B", "num_var_A", "num_var_B"],
         bins=2,
         scoring="neg_root_mean_squared_error",
@@ -166,7 +169,7 @@ def test_regression():
 def test_cv_generator():
     X, y = df_classification()
     cv = StratifiedKFold(n_splits=2)
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=None,
         scoring="accuracy",
         threshold=None,
@@ -180,23 +183,23 @@ def test_cv_generator():
 
 def test_error_wrong_params():
     with pytest.raises(ValueError):
-        SelectByTargetMeanPerformance(scoring="mean_squared")
+        SelectByTargetEncoding(scoring="mean_squared")
     with pytest.raises(ValueError):
-        SelectByTargetMeanPerformance(scoring=1)
+        SelectByTargetEncoding(scoring=1)
     with pytest.raises(ValueError):
-        SelectByTargetMeanPerformance(threshold="hola")
+        SelectByTargetEncoding(threshold="hola")
     with pytest.raises(ValueError):
-        SelectByTargetMeanPerformance(bins="hola")
+        SelectByTargetEncoding(bins="hola")
     with pytest.raises(ValueError):
-        SelectByTargetMeanPerformance(strategy="hola")
+        SelectByTargetEncoding(strategy="hola")
     with pytest.raises(ValueError):
-        SelectByTargetMeanPerformance(regression=True, scoring="hola")
+        SelectByTargetEncoding(regression=True, scoring="hola")
 
 
 def test_raises_error_if_evaluating_single_variable_and_threshold_is_None(df_test):
     X, y = df_test
 
-    sel = SelectByTargetMeanPerformance(variables=["var_1"], threshold=None)
+    sel = SelectByTargetEncoding(variables=["var_1"], threshold=None)
 
     with pytest.raises(ValueError):
         sel.fit(X, y)
@@ -206,7 +209,7 @@ def test_test_selector_with_one_variable():
 
     X, y = df_regression()
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=["cat_var_A"],
         bins=2,
         scoring="neg_root_mean_squared_error",
@@ -227,7 +230,7 @@ def test_test_selector_with_one_variable():
 
     X, y = df_regression()
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         variables=["cat_var_B"],
         bins=2,
         scoring="neg_root_mean_squared_error",
@@ -256,7 +259,7 @@ def test_target_mean_selection_with_groups(df_test_with_groups):
     scoring = "neg_mean_absolute_error"
     regression = True
 
-    sel_expected = SelectByTargetMeanPerformance(
+    sel_expected = SelectByTargetEncoding(
         scoring=scoring,
         cv=cv_indices,
         regression=regression,
@@ -264,7 +267,7 @@ def test_target_mean_selection_with_groups(df_test_with_groups):
 
     X_tr_expected = sel_expected.fit_transform(X, y)
 
-    sel = SelectByTargetMeanPerformance(
+    sel = SelectByTargetEncoding(
         scoring=scoring,
         cv=cv,
         groups=groups,
@@ -274,3 +277,32 @@ def test_target_mean_selection_with_groups(df_test_with_groups):
     X_tr = sel.fit_transform(X, y)
 
     pd.testing.assert_frame_equal(X_tr, X_tr_expected)
+
+
+def test_select_by_target_mean_performance_is_deprecated():
+    """SelectByTargetMeanPerformance should emit a FutureWarning and still work."""
+    X, y = df_classification()
+
+    with pytest.warns(
+        FutureWarning, match="SelectByTargetMeanPerformance was deprecated"
+    ):
+        sel = SelectByTargetMeanPerformance(
+            variables=None,
+            scoring="accuracy",
+            threshold=None,
+            bins=2,
+            strategy="equal_width",
+            cv=2,
+        )
+    assert isinstance(sel, SelectByTargetEncoding)
+
+    sel_new = SelectByTargetEncoding(
+        variables=None,
+        scoring="accuracy",
+        threshold=None,
+        bins=2,
+        strategy="equal_width",
+        cv=2,
+    )
+
+    pd.testing.assert_frame_equal(sel.fit_transform(X, y), sel_new.fit_transform(X, y))


### PR DESCRIPTION
## Summary

- Renames `SelectByTargetMeanPerformance` to `SelectByTargetEncoding`, a name describing the mechanism (target/mean encoding used as a performance proxy).
- `SelectBySingleFeaturePerformance` is left unchanged, as decided.
- The old class name is kept as a deprecated alias (`FutureWarning` on instantiation), to be removed in 2.1.0, following the same pattern as the recent `MeanImputer`, `MissingIndicator`, `Winsoriser`, `ArbitraryImputer` and `SklearnWrapper` renames.
- Updates API docs, user guide (renamed rst files + toctree/table refs), README, and docstrings.
- Tests: both the new class and the deprecated alias are exercised — the estimator-compatibility suite (`test_check_estimator_selectors.py`) now runs both through the full sklearn/feature-engine check battery, and `test_target_mean_selection.py` has a dedicated deprecation test asserting the `FutureWarning` and behavioural equivalence with the new class.

## Test plan

- [x] `pytest tests/` (2077 passed)
- [x] `flake8 feature_engine tests`
- [x] `mypy feature_engine/selection`
- [x] `sphinx-build -W -b html docs <out>` (clean build, 0 warnings)
