### PR TITLE
Rename CountFrequencyEncoder to CountEncoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Please share your story by answering 1 quick question
 ### Encoding Methods
 * OneHotEncoder
 * OrdinalEncoder
-* CountFrequencyEncoder
+* CountEncoder
 * MeanEncoder
 * WoEEncoder
 * RareLabelEncoder

--- a/docs/api_doc/encoding/CountEncoder.rst
+++ b/docs/api_doc/encoding/CountEncoder.rst
@@ -1,0 +1,5 @@
+CountEncoder
+============
+
+.. autoclass:: feature_engine.encoding.CountEncoder
+    :members:

--- a/docs/api_doc/encoding/CountFrequencyEncoder.rst
+++ b/docs/api_doc/encoding/CountFrequencyEncoder.rst
@@ -1,5 +1,0 @@
-CountFrequencyEncoder
-=====================
-
-.. autoclass:: feature_engine.encoding.CountFrequencyEncoder
-    :members:

--- a/docs/api_doc/encoding/index.rst
+++ b/docs/api_doc/encoding/index.rst
@@ -13,7 +13,7 @@ estimated or arbitrary numbers.
 ================================= ============ ================= ============== ===============================================================
 :class:`OneHotEncoder()`	           √	            √               √         Adds dummy variables to represent each category
 :class:`OrdinalEncoder()`	           √	            √    	        √         Replaces categories with an integer
-:class:`CountFrequencyEncoder()`	       √	            √               √         Replaces categories with their count or frequency
+:class:`CountEncoder()`           √            √                 √              Replaces categories with their count or frequency
 :class:`MeanEncoder()`                 √	            √               x         Replaces categories with the target mean value
 :class:`WoEEncoder()`	               x	            √	            x         Replaces categories with the weight of the evidence
 :class:`DecisionTreeEncoder()`	       √	            √     	        √         Replaces categories with the predictions of a decision tree
@@ -30,7 +30,7 @@ input.
    :maxdepth: 1
 
    OneHotEncoder
-   CountFrequencyEncoder
+   CountEncoder
    OrdinalEncoder
    MeanEncoder
    WoEEncoder

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -198,7 +198,7 @@ There are various categorical encoding techniques, including one hot encoding, o
 Feature-engine supports the following methods:
 
 - :doc:`api_doc/encoding/OneHotEncoder`: performs one hot encoding, optional: of popular categories
-- :doc:`api_doc/encoding/CountFrequencyEncoder`: replaces categories with the observation count or percentage
+- :doc:`api_doc/encoding/CountEncoder`: replaces categories with the observation count or percentage
 - :doc:`api_doc/encoding/OrdinalEncoder`: replaces categories with integers, either arbitrarily or informed by target
 - :doc:`api_doc/encoding/MeanEncoder`: replaces categories with the target mean
 - :doc:`api_doc/encoding/WoEEncoder`: replaces categories with the weight of evidence

--- a/docs/user_guide/encoding/CountEncoder.rst
+++ b/docs/user_guide/encoding/CountEncoder.rst
@@ -2,8 +2,14 @@
 
 .. currentmodule:: feature_engine.encoding
 
-CountFrequencyEncoder
-=====================
+CountEncoder
+============
+
+.. note::
+
+    **Renamed in version 2.0:** ``CountFrequencyEncoder`` was renamed to
+    ``CountEncoder``. The old name is still available for backwards compatibility
+    but will be removed in version 2.1.0.
 
 Count encoding and frequency encoding are 2 categorical encoding techniques that were
 commonly used during data preprocessing in Kaggle's data science competitions, even when
@@ -42,20 +48,20 @@ categories with similar counts would show similar patterns or behaviours.
 Count and frequency encoding with feature-engine
 ------------------------------------------------
 
-The :class:`CountFrequencyEncoder()` replaces categories of categorical features by
+The :class:`CountEncoder()` replaces categories of categorical features by
 either the count or the percentage of observations each category shows in the training set.
 
-With :class:`CountFrequencyEncoder()` we can automatically encode all categorical
+With :class:`CountEncoder()` we can automatically encode all categorical
 features in the dataset, or only a subset of them, by passing the variable names in a
 list to the `variables` parameter when we set up the encoder.
 
-By default, :class:`CountFrequencyEncoder()` will encode only categorical data. If we
+By default, :class:`CountEncoder()` will encode only categorical data. If we
 want to encode numerical values, we need to explicitly say so by setting the parameter
 `ignore_format` to True.
 
 .. attention::
 
-    **New in version 2.0:** When `variables` is `None`, :class:`CountFrequencyEncoder()` used to
+    **New in version 2.0:** When `variables` is `None`, :class:`CountEncoder()` used to
     raise an error if the dataframe contained no categorical variables. You can now
     set the new parameter `return_empty` to `True` to make the transformer return an
     empty list of variables and skip the encoding instead, leaving the dataframe
@@ -72,7 +78,7 @@ encoding techniques like ordinal encoding or target encoding, we do so by observ
 categories in the training set. Hence, we won't have mappings for categories that appear
 only in the test set. These are the so-called "unseen categories."
 
-When encountering unseen categories, :class:`CountFrequencyEncoder()` will ignore them
+When encountering unseen categories, :class:`CountEncoder()` will ignore them
 by default, which means that unseen categories will be replaced with missing values.
 We can instruct the encoder to raise an error when a new category is encountered, or
 alternatively, to encode unseen categories with zero.
@@ -87,7 +93,7 @@ From one categorical variable, we obtain one numerical feature.
 Python example
 --------------
 
-Let's examine the functionality of :class:`CountFrequencyEncoder()` by using the Titanic
+Let's examine the functionality of :class:`CountEncoder()` by using the Titanic
 dataset. We'll start by loading the libraries and functions, loading the dataset, and then
 splitting it into a training and a testing set.
 
@@ -95,7 +101,7 @@ splitting it into a training and a testing set.
 
     from sklearn.model_selection import train_test_split
     from feature_engine.datasets import load_titanic
-    from feature_engine.encoding import CountFrequencyEncoder
+    from feature_engine.encoding import CountEncoder
 
     X, y = load_titanic(
         return_X_y_frame=True,
@@ -133,7 +139,7 @@ dataset.
 
 .. code:: python
 
-    encoder = CountFrequencyEncoder(
+    encoder = CountEncoder(
     encoding_method='count',
     variables=['cabin', 'sex', 'embarked'],
     )
@@ -195,7 +201,7 @@ hence, we need to set the encoder to ignore the variable's type:
 
 .. code:: python
 
-    encoder = CountFrequencyEncoder(
+    encoder = CountEncoder(
     encoding_method='frequency',
     variables=['cabin', 'pclass', 'embarked'],
     ignore_format=True,

--- a/docs/user_guide/encoding/MeanEncoder.rst
+++ b/docs/user_guide/encoding/MeanEncoder.rst
@@ -83,7 +83,7 @@ together by replacing them with values very close to the overall target mean cal
 over the training data.
 
 Another encoding method that tackles cardinality out of the box is count encoding. See for
-example :class:`CountFrequencyEncoder`.
+example :class:`CountEncoder`.
 
 To account for highly cardinal variables in alternative encoding methods, you can group
 rare categories together by using the :class:`RareLabelEncoder`.

--- a/docs/user_guide/encoding/index.rst
+++ b/docs/user_guide/encoding/index.rst
@@ -215,7 +215,7 @@ categories, we can assign them a frequency or count of '0' explicitly, which rep
 the frequency of the category on the training set, to prevent failure during inference 
 time (i.e., while making predictions) or while encoding live data.
 
-Feature-engine's :class:`CountFrequencyEncoder` implements count and frequency encoding.
+Feature-engine's :class:`CountEncoder` implements count and frequency encoding.
 
 Mean Encoding
 ~~~~~~~~~~~~~
@@ -318,7 +318,7 @@ Summary of feature-engine's encoders characteristics
 =================================== ============ ================= ============== ===============================================================
 :class:`OneHotEncoder()`	           √	            √               √         Adds dummy variables to represent each category
 :class:`OrdinalEncoder()`	           √	            √    	        √         Replaces categories with an integer
-:class:`CountFrequencyEncoder()`	   √	            √               √         Replaces categories with their count or frequency
+:class:`CountEncoder()`             √            √                 √              Replaces categories with their count or frequency
 :class:`MeanEncoder()`                 √	            √               x         Replaces categories with the targe mean value
 :class:`WoEEncoder()`	               x	            √	            x         Replaces categories with the weight of the evidence
 :class:`DecisionTreeEncoder()`	       √	            √     	        √         Replaces categories with the predictions of a decision tree
@@ -357,7 +357,7 @@ Multi-class classification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Finally, some feature-engine's encoders can handle multi-class targets off-the-shelf for
-example the :class:`OneHotEncoder()`, the :class:`CountFrequencyEncoder()` and the
+example the :class:`OneHotEncoder()`, the :class:`CountEncoder()` and the
 :class:`DecisionTreeEncoder()`.
 
 Note that while the :class:`MeanEncoder()` and the :class:`OrdinalEncoder()` will operate
@@ -396,7 +396,7 @@ Encoders
 
    OneHotEncoder
    OrdinalEncoder
-   CountFrequencyEncoder
+   CountEncoder
    MeanEncoder
    WoEEncoder
    StringSimilarityEncoder

--- a/feature_engine/encoding/__init__.py
+++ b/feature_engine/encoding/__init__.py
@@ -2,7 +2,7 @@
 The module encoding includes classes to transform categorical variables into numerical.
 """
 
-from .count_frequency import CountFrequencyEncoder
+from .count_frequency import CountEncoder, CountFrequencyEncoder
 from .decision_tree import DecisionTreeEncoder
 from .mean_encoding import MeanEncoder
 from .one_hot import OneHotEncoder
@@ -12,6 +12,7 @@ from .similarity_encoder import StringSimilarityEncoder
 from .woe import WoEEncoder
 
 __all__ = [
+    "CountEncoder",
     "CountFrequencyEncoder",
     "DecisionTreeEncoder",
     "MeanEncoder",

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -1,6 +1,7 @@
 # Authors: Soledad Galli <solegalli@protonmail.com>
 # License: BSD 3 clause
 
+import warnings
 from typing import List, Optional, Union
 
 import pandas as pd
@@ -54,16 +55,16 @@ _unseen_docstring = (
     transform=_transform_encoders_docstring,
     inverse_transform=_inverse_transform_docstring,
 )
-class CountFrequencyEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
+class CountEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
     """
-    The CountFrequencyEncoder() replaces categories by either the count or the
+    The CountEncoder() replaces categories by either the count or the
     percentage of observations per category.
 
     For example in the variable colour, if 10 observations are blue, blue will
     be replaced by 10. Alternatively, if 10% of the observations are blue, blue
     will be replaced by 0.1.
 
-    The CountFrequencyEncoder() will encode only categorical variables by default
+    The CountEncoder() will encode only categorical variables by default
     (type 'object' or 'categorical'). You can pass a list of variables to encode.
     Alternatively, the encoder will find and encode all categorical variables
     (type 'object' or 'categorical').
@@ -137,9 +138,9 @@ class CountFrequencyEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
     --------
 
     >>> import pandas as pd
-    >>> from feature_engine.encoding import CountFrequencyEncoder
+    >>> from feature_engine.encoding import CountEncoder
     >>> X = pd.DataFrame(dict(x1 = [1,2,3,4], x2 = ["c", "a", "b", "c"]))
-    >>> cf = CountFrequencyEncoder(encoding_method='count')
+    >>> cf = CountEncoder(encoding_method='count')
     >>> cf.fit(X)
     >>> cf.transform(X)
        x1  x2
@@ -148,7 +149,7 @@ class CountFrequencyEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
     2   3   1
     3   4   2
 
-    >>> cf = CountFrequencyEncoder(encoding_method='frequency')
+    >>> cf = CountEncoder(encoding_method='frequency')
     >>> cf.fit(X)
     >>> cf.transform(X)
        x1    x2
@@ -222,3 +223,31 @@ class CountFrequencyEncoder(CategoricalMethodsMixin, CategoricalInitMixinNA):
         self.variables_ = variables_
         self._get_feature_names_in(X)
         return self
+
+
+# TODO: remove in version 2.1.0
+class CountFrequencyEncoder(CountEncoder):
+    def __init__(
+        self,
+        encoding_method: str = "count",
+        variables: Union[None, int, str, List[Union[str, int]]] = None,
+        return_empty: bool = False,
+        missing_values: str = "raise",
+        ignore_format: bool = False,
+        unseen: str = "ignore",
+    ) -> None:
+        warnings.warn(
+            "CountFrequencyEncoder was deprecated in favour of CountEncoder in "
+            "version 2.0.0 and will be removed in version 2.1.0. To silence this "
+            "warning, use CountEncoder instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            encoding_method=encoding_method,
+            variables=variables,
+            return_empty=return_empty,
+            missing_values=missing_values,
+            ignore_format=ignore_format,
+            unseen=unseen,
+        )

--- a/tests/check_estimators_with_parametrize_tests.py
+++ b/tests/check_estimators_with_parametrize_tests.py
@@ -15,7 +15,7 @@ from feature_engine.creation import (
     RelativeFeatures,
 )
 from feature_engine.encoding import (
-    CountFrequencyEncoder,
+    CountEncoder,
     DecisionTreeEncoder,
     MeanEncoder,
     OneHotEncoder,
@@ -103,7 +103,7 @@ def test_sklearn_compatible_imputer(estimator, check):
 # encoding
 @parametrize_with_checks(
     [
-        CountFrequencyEncoder(ignore_format=True),
+        CountEncoder(ignore_format=True),
         DecisionTreeEncoder(regression=False, ignore_format=True),
         MeanEncoder(ignore_format=True),
         OneHotEncoder(ignore_format=True),

--- a/tests/parametrize_with_checks_encoders_v16.py
+++ b/tests/parametrize_with_checks_encoders_v16.py
@@ -7,7 +7,7 @@ Works from sklearn > 1.6.
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from feature_engine.encoding import (
-    CountFrequencyEncoder,
+    CountEncoder,
     MeanEncoder,
     OneHotEncoder,
     OrdinalEncoder,
@@ -17,7 +17,7 @@ from feature_engine.encoding import (
 )
 from feature_engine.tags import _return_tags
 
-ce = CountFrequencyEncoder(ignore_format=True)
+ce = CountEncoder(ignore_format=True)
 me = MeanEncoder(ignore_format=True)
 ohe = OneHotEncoder(ignore_format=True)
 oe = OrdinalEncoder(ignore_format=True)
@@ -34,7 +34,7 @@ FAILED_CHECKS = _return_tags()["_xfail_checks"]
 FAILED_CHECKS.update({"check_estimators_nan_inf": "transformer allows NA"})
 
 EXPECTED_FAILED_CHECKS = {
-    "CountFrequencyEncoder": FAILED_CHECKS,
+    "CountEncoder": FAILED_CHECKS,
     "MeanEncoder": FAILED_CHECKS,
     "OneHotEncoder": FAILED_CHECKS,
     "OrdinalEncoder": FAILED_CHECKS,

--- a/tests/test_encoding/test_check_estimator_encoders.py
+++ b/tests/test_encoding/test_check_estimator_encoders.py
@@ -9,6 +9,7 @@ from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.fixes import parse_version
 
 from feature_engine.encoding import (
+    CountEncoder,
     CountFrequencyEncoder,
     DecisionTreeEncoder,
     MeanEncoder,
@@ -27,6 +28,7 @@ from tests.estimator_checks.estimator_checks import (
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
 _estimators = [
+    CountEncoder(ignore_format=True),
     CountFrequencyEncoder(ignore_format=True),
     # breaks with sklearn 1.4.1 - check and fix?
     # DecisionTreeEncoder(regression=False, ignore_format=True),
@@ -63,6 +65,7 @@ else:
 
 
 _estimators = [
+    CountEncoder(),
     CountFrequencyEncoder(),
     DecisionTreeEncoder(regression=False),
     MeanEncoder(),

--- a/tests/test_encoding/test_count_frequency_encoder.py
+++ b/tests/test_encoding/test_count_frequency_encoder.py
@@ -5,14 +5,14 @@ import pytest
 from numpy import nan
 from sklearn.exceptions import NotFittedError
 
-from feature_engine.encoding import CountFrequencyEncoder
+from feature_engine.encoding import CountEncoder, CountFrequencyEncoder
 
 
 # init parameters
 @pytest.mark.parametrize("enc_method", ["arbitrary", False, 1])
 def test_error_if_encoding_method_not_permitted_value(enc_method):
     with pytest.raises(ValueError):
-        CountFrequencyEncoder(encoding_method=enc_method)
+        CountEncoder(encoding_method=enc_method)
 
 
 @pytest.mark.parametrize(
@@ -20,14 +20,14 @@ def test_error_if_encoding_method_not_permitted_value(enc_method):
 )
 def test_error_if_unseen_gets_not_permitted_value(errors):
     with pytest.raises(ValueError):
-        CountFrequencyEncoder(unseen=errors)
+        CountEncoder(unseen=errors)
 
 
 @pytest.mark.parametrize(
     "params", [("count", "raise", True), ("frequency", "ignore", False)]
 )
 def test_init_param_assignment(params):
-    enc = CountFrequencyEncoder(
+    enc = CountEncoder(
         encoding_method=params[0],
         missing_values=params[1],
         ignore_format=params[2],
@@ -42,7 +42,7 @@ def test_init_param_assignment(params):
 # fit and transform
 def test_encode_1_variable_with_counts(df_enc):
     # test case 1: 1 variable, counts
-    encoder = CountFrequencyEncoder(encoding_method="count", variables=["var_A"])
+    encoder = CountEncoder(encoding_method="count", variables=["var_A"])
     X = encoder.fit_transform(df_enc)
 
     # expected result
@@ -83,7 +83,7 @@ def test_encode_1_variable_with_counts(df_enc):
 
 def test_automatically_select_variables_encode_with_frequency(df_enc):
     # test case 2: automatically select variables, frequency
-    encoder = CountFrequencyEncoder(encoding_method="frequency", variables=None)
+    encoder = CountEncoder(encoding_method="frequency", variables=None)
     X = encoder.fit_transform(df_enc)
 
     # expected output
@@ -151,7 +151,7 @@ def test_encoding_when_nan_in_fit_df(df_enc):
     df = df_enc.copy()
     df.loc[len(df)] = [nan, nan, nan]
 
-    encoder = CountFrequencyEncoder(
+    encoder = CountEncoder(
         encoding_method="frequency",
         missing_values="ignore",
     )
@@ -170,7 +170,7 @@ def test_encoding_when_nan_in_fit_df(df_enc):
 
 @pytest.mark.parametrize("enc_method", ["arbitrary", False, 1])
 def test_error_if_encoding_method_not_recognized_in_fit(enc_method, df_enc):
-    enc = CountFrequencyEncoder()
+    enc = CountEncoder()
     enc.encoding_method = enc_method
     with pytest.raises(ValueError) as record:
         enc.fit(df_enc)
@@ -188,7 +188,7 @@ def test_warning_when_df_contains_unseen_categories(df_enc, df_enc_rare):
     msg = "During the encoding, NaN values were introduced in the feature(s) var_A."
 
     # check for warning when unseen equals 'ignore'
-    encoder = CountFrequencyEncoder(unseen="ignore")
+    encoder = CountEncoder(unseen="ignore")
     encoder.fit(df_enc)
     with pytest.warns(UserWarning) as record:
         encoder.transform(df_enc_rare)
@@ -205,7 +205,7 @@ def test_error_when_df_contains_unseen_categories(df_enc, df_enc_rare):
 
     msg = "During the encoding, NaN values were introduced in the feature(s) var_A."
 
-    encoder = CountFrequencyEncoder(unseen="raise")
+    encoder = CountEncoder(unseen="raise")
     encoder.fit(df_enc)
 
     # check for exception when unseen equals 'raise'
@@ -218,7 +218,7 @@ def test_error_when_df_contains_unseen_categories(df_enc, df_enc_rare):
     # check for no error and no warning when unseen equals 'encode'
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        encoder = CountFrequencyEncoder(unseen="encode")
+        encoder = CountEncoder(unseen="encode")
         encoder.fit(df_enc)
         encoder.transform(df_enc_rare)
 
@@ -231,7 +231,7 @@ def test_no_error_triggered_when_df_contains_unseen_categories_and_unseen_is_enc
 
     # check for no error and no warning when unseen equals 'encode'
     warnings.simplefilter("error")
-    encoder = CountFrequencyEncoder(unseen="encode")
+    encoder = CountEncoder(unseen="encode")
     encoder.fit(df_enc)
     with warnings.catch_warnings():
         encoder.transform(df_enc_rare)
@@ -240,7 +240,7 @@ def test_no_error_triggered_when_df_contains_unseen_categories_and_unseen_is_enc
 @pytest.mark.parametrize("errors", ["raise", "ignore", "encode"])
 def test_fit_raises_error_if_df_contains_na(errors, df_enc_na):
     # test case 4: when dataset contains na, fit method
-    encoder = CountFrequencyEncoder(unseen=errors)
+    encoder = CountEncoder(unseen=errors)
     with pytest.raises(ValueError) as record:
         encoder.fit(df_enc_na)
     msg = (
@@ -254,7 +254,7 @@ def test_fit_raises_error_if_df_contains_na(errors, df_enc_na):
 @pytest.mark.parametrize("errors", ["raise", "ignore", "encode"])
 def test_transform_raises_error_if_df_contains_na(errors, df_enc, df_enc_na):
     # test case 4: when dataset contains na, transform method
-    encoder = CountFrequencyEncoder(unseen=errors)
+    encoder = CountEncoder(unseen=errors)
     encoder.fit(df_enc)
     with pytest.raises(ValueError) as record:
         encoder.transform(df_enc_na)
@@ -274,7 +274,7 @@ def test_zero_encoding_for_new_categories():
     df_transf = pd.DataFrame(
         {"col1": ["a", "d", "b", "a", "c"], "col2": ["1", "2", "3", "1", "4"]}
     )
-    encoder = CountFrequencyEncoder(unseen="encode").fit(df_fit)
+    encoder = CountEncoder(unseen="encode").fit(df_fit)
 
     result = encoder.transform(df_transf)
 
@@ -295,7 +295,7 @@ def test_zero_encoding_for_unseen_categories_if_unseen_is_encode():
     )
 
     # count encoding
-    encoder = CountFrequencyEncoder(unseen="encode").fit(df_fit)
+    encoder = CountEncoder(unseen="encode").fit(df_fit)
     result = encoder.transform(df_transform)
 
     # check that no NaNs are added
@@ -306,7 +306,7 @@ def test_zero_encoding_for_unseen_categories_if_unseen_is_encode():
     pd.testing.assert_frame_equal(result, expected_result, check_dtype=False)
 
     # with frequency
-    encoder = CountFrequencyEncoder(encoding_method="frequency", unseen="encode").fit(
+    encoder = CountEncoder(encoding_method="frequency", unseen="encode").fit(
         df_fit
     )
     result = encoder.transform(df_transform)
@@ -328,7 +328,7 @@ def test_nan_encoding_for_new_categories_if_unseen_is_ignore():
     df_transf = pd.DataFrame(
         {"col1": ["a", "d", "b", "a", "c"], "col2": ["1", "2", "3", "1", "4"]}
     )
-    encoder = CountFrequencyEncoder(unseen="ignore").fit(df_fit)
+    encoder = CountEncoder(unseen="ignore").fit(df_fit)
     result = encoder.transform(df_transf)
 
     # check that no NaNs are added
@@ -342,7 +342,7 @@ def test_nan_encoding_for_new_categories_if_unseen_is_ignore():
 
 
 def test_ignore_variable_format_with_frequency(df_vartypes):
-    encoder = CountFrequencyEncoder(
+    encoder = CountEncoder(
         encoding_method="frequency", variables=None, ignore_format=True
     )
     X = encoder.fit_transform(df_vartypes)
@@ -369,7 +369,7 @@ def test_ignore_variable_format_with_frequency(df_vartypes):
 
 
 def test_column_names_are_numbers(df_numeric_columns):
-    encoder = CountFrequencyEncoder(
+    encoder = CountEncoder(
         encoding_method="frequency", variables=[0, 1, 2, 3], ignore_format=True
     )
     X = encoder.fit_transform(df_numeric_columns)
@@ -396,7 +396,7 @@ def test_column_names_are_numbers(df_numeric_columns):
 
 
 def test_variables_cast_as_category(df_enc_category_dtypes):
-    encoder = CountFrequencyEncoder(encoding_method="count", variables=["var_A"])
+    encoder = CountEncoder(encoding_method="count", variables=["var_A"])
     X = encoder.fit_transform(df_enc_category_dtypes)
 
     # expected result
@@ -427,14 +427,14 @@ def test_variables_cast_as_category(df_enc_category_dtypes):
     pd.testing.assert_frame_equal(X, transf_df, check_dtype=False)
     assert X["var_A"].dtypes == int
 
-    encoder = CountFrequencyEncoder(encoding_method="frequency", variables=["var_A"])
+    encoder = CountEncoder(encoding_method="frequency", variables=["var_A"])
     X = encoder.fit_transform(df_enc_category_dtypes)
     assert X["var_A"].dtypes == float
 
 
 def test_inverse_transform_when_no_unseen():
     df = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", "bird"]})
-    enc = CountFrequencyEncoder()
+    enc = CountEncoder()
     enc.fit(df)
     dft = enc.transform(df)
     pd.testing.assert_frame_equal(enc.inverse_transform(dft), df)
@@ -444,7 +444,7 @@ def test_inverse_transform_when_ignore_unseen():
     df1 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", "bird"]})
     df2 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", "frog"]})
     df3 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", nan]})
-    enc = CountFrequencyEncoder(unseen="ignore")
+    enc = CountEncoder(unseen="ignore")
     enc.fit(df1)
     dft = enc.transform(df2)
     pd.testing.assert_frame_equal(enc.inverse_transform(dft), df3)
@@ -454,7 +454,7 @@ def test_inverse_transform_when_encode_unseen():
     df1 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", "bird"]})
     df2 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", "frog"]})
     df3 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", nan]})
-    enc = CountFrequencyEncoder(unseen="encode")
+    enc = CountEncoder(unseen="encode")
     enc.fit(df1)
     dft = enc.transform(df2)
     pd.testing.assert_frame_equal(enc.inverse_transform(dft), df3)
@@ -462,7 +462,7 @@ def test_inverse_transform_when_encode_unseen():
 
 def test_inverse_transform_raises_non_fitted_error():
     df1 = pd.DataFrame({"words": ["dog", "dog", "cat", "cat", "cat", "bird"]})
-    enc = CountFrequencyEncoder()
+    enc = CountEncoder()
 
     # Test when fit is not called prior to transform.
     with pytest.raises(NotFittedError):
@@ -476,3 +476,18 @@ def test_inverse_transform_raises_non_fitted_error():
     # Test when fit is not called prior to transform.
     with pytest.raises(NotFittedError):
         enc.inverse_transform(df1)
+
+
+def test_count_frequency_encoder_is_deprecated():
+    """CountFrequencyEncoder should emit a FutureWarning and still work."""
+    X = pd.DataFrame({"var_A": ["A"] * 6 + ["B"] * 2 + ["C"] * 2})
+
+    with pytest.warns(FutureWarning, match="CountFrequencyEncoder was deprecated"):
+        enc = CountFrequencyEncoder(encoding_method="count")
+    assert isinstance(enc, CountEncoder)
+
+    enc_new = CountEncoder(encoding_method="count")
+
+    pd.testing.assert_frame_equal(
+        enc.fit_transform(X), enc_new.fit_transform(X)
+    )


### PR DESCRIPTION
## Summary

- Renames `CountFrequencyEncoder` to `CountEncoder` for a shorter name.
- The old class name is kept as a deprecated alias (`FutureWarning` on instantiation), to be removed in 2.1.0, following the same pattern as the recent `MeanImputer`, `MissingIndicator`, `Winsoriser`, `ArbitraryImputer`, `SklearnWrapper` and `SelectByTargetEncoding` renames.
- Updates API docs, user guide (renamed rst files + toctree/table refs, including the cross-reference from `MeanEncoder.rst`), README, and docstrings.
- Tests: both the new class and the deprecated alias are exercised — the estimator-compatibility suite (`test_check_estimator_encoders.py`) now runs both through the full sklearn/feature-engine check battery, and `test_count_frequency_encoder.py` has a dedicated deprecation test asserting the `FutureWarning` and behavioural equivalence with the new class.

## Test plan

- [x] `pytest tests/` (2077 passed)
- [x] `flake8 feature_engine tests`
- [x] `mypy feature_engine/encoding`
- [x] `sphinx-build -W -b html docs <out>` (clean build, 0 warnings)
