### PR TITLE
Fix incorrect precision example in GeometricWidthDiscretiser docs

### DIFF
--- a/docs/user_guide/discretisation/GeometricWidthDiscretiser.rst
+++ b/docs/user_guide/discretisation/GeometricWidthDiscretiser.rst
@@ -43,7 +43,7 @@ This discretisation technique is great when the distribution of the variable is 
     to work properly, it might help to increase the precision value, that is,
     the number of decimal values allowed to define each bin. If the variable has a
     narrow range or you are sorting into several bins, allow greater precision
-    (i.e., if precision = 3, then 0.001; if precision = 7, then 0.0001).
+    (i.e., if precision = 3, then 0.001; if precision = 7, then 0.0000001).
 
 :class:`GeometricWidthDiscretiser()` works only with numerical variables. A list of
 variables to discretise can be indicated, or the discretiser will automatically select

--- a/feature_engine/discretisation/geometric_width.py
+++ b/feature_engine/discretisation/geometric_width.py
@@ -84,7 +84,7 @@ class GeometricWidthDiscretiser(BaseDiscretiser):
     to work properly, it might help to increase the precision value, that is,
     the number of decimal values allowed to define each bin. If the variable has a
     narrow range or you are sorting into several bins, allow greater precision
-    (i.e., if precision = 3, then 0.001; if precision = 7, then 0.0001).
+    (i.e., if precision = 3, then 0.001; if precision = 7, then 0.0000001).
 
     The :class:`GeometricWidthDiscretiser()` works only with numerical variables.
     A list of variables to discretise can be indicated, or the discretiser will


### PR DESCRIPTION
The `GeometricWidthDiscretiser` guidance on the `precision` parameter gives an inconsistent worked example.

`precision` is the number of decimal places (forwarded to `pd.cut(..., precision=...)`), so `precision = N` corresponds to a smallest step of `10**-N`. The tip establishes this with its first example (`precision = 3` -> `0.001`), but then states `precision = 7` -> `0.0001`, which is `10**-4`, not `10**-7`. The correct value is `0.0000001`.

Fixed in both places the sentence appears (kept in sync):
- `feature_engine/discretisation/geometric_width.py` (docstring)
- `docs/user_guide/discretisation/GeometricWidthDiscretiser.rst`

Documentation-only; no code or behavior changes.