### PR TITLE
BUG - Compute lexical_diversity as unique words over total words

### DIFF
--- a/docs/user_guide/text/TextFeatures.rst
+++ b/docs/user_guide/text/TextFeatures.rst
@@ -246,7 +246,7 @@ The output dataframe contains all 20 text features extracted from the `review` c
 
        review_unique_word_count  review_lexical_diversity
     0                         7                       1.0
-    1                         4                      1.25
+    1                         4                       0.8
     2                         9                       1.0
     3                         4                       1.0
 

--- a/feature_engine/text/text_features.py
+++ b/feature_engine/text/text_features.py
@@ -41,8 +41,8 @@ TEXT_FEATURES = {
     "starts_with_uppercase": lambda x: x.str.match(r"^[A-Z]").astype(int),
     "ends_with_punctuation": lambda x: x.str.match(r".*[.!?]$").astype(int),
     "unique_word_count": lambda x: (x.str.lower().str.split().apply(set).str.len()),
-    "lexical_diversity": lambda x: x.str.strip().str.split().str.len()
-    / x.str.lower().str.split().apply(set).str.len(),
+    "lexical_diversity": lambda x: x.str.lower().str.split().apply(set).str.len()
+    / x.str.strip().str.split().str.len(),
 }
 
 

--- a/tests/test_text/test_text_features.py
+++ b/tests/test_text/test_text_features.py
@@ -778,3 +778,21 @@ def test_get_feature_names_out_with_drop():
     feature_names = transformer.get_feature_names_out()
     expected_features = ["other", "text_char_count"]
     assert feature_names == expected_features
+
+
+def test_lexical_diversity_is_unique_words_over_total_words():
+    X = pd.DataFrame(
+        {
+            "text": [
+                "the cat sat on the mat",  # 6 words, 5 unique
+                "good good good good",  # 4 words, 1 unique
+                "all words here are distinct",  # 5 words, 5 unique
+            ]
+        }
+    )
+    transformer = TextFeatures(variables=["text"], features=["lexical_diversity"])
+    X_tr = transformer.fit_transform(X)
+
+    assert X_tr["text_lexical_diversity"].tolist() == [5 / 6, 1 / 4, 1.0]
+    # a ratio of unique words to total words never exceeds 1
+    assert (X_tr["text_lexical_diversity"] <= 1.0).all()


### PR DESCRIPTION
`lexical_diversity` is documented as:

> **lexical_diversity**: Ratio of unique words to total words

but the implementation divides the other way round:

```python
"lexical_diversity": lambda x: x.str.strip().str.split().str.len()
/ x.str.lower().str.split().apply(set).str.len(),
```

so it returns the reciprocal of the documented value.

Two things make this visible:

- A type-token ratio cannot exceed 1, but the current feature returns values greater than 1 for any text that repeats a word.
- It grows with repetition instead of with variety, which is the opposite of what the user guide states: *"in more complex texts, both the number of unique words and the lexical diversity are greater."*

```python
import pandas as pd
from feature_engine.text import TextFeatures

X = pd.DataFrame({"review": [
    "the cat sat on the mat",       # 6 words, 5 unique
    "good good good good",          # 4 words, 1 unique
    "all words here are distinct",  # 5 words, 5 unique
]})
print(TextFeatures(variables=["review"],
                   features=["lexical_diversity"]).fit_transform(X))
```

On `main`:

```
review_lexical_diversity
                     1.2
                     4.0
                     1.0
```

With this PR:

```
review_lexical_diversity
                0.833333
                0.250000
                1.000000
```

`"good good good good"` is four tokens of a single word — the least diverse row in the frame — and it currently gets the highest score, 4.0, instead of 1/4.

This swaps the operands so the numerator is the unique word count, reusing exactly the expression the neighbouring `unique_word_count` feature already uses. The example output in `docs/user_guide/text/TextFeatures.rst` is updated to match (row 1 goes from an impossible `1.25` to `0.8`).

Added a regression test. It fails on `main` and passes here; the rest of `tests/test_text/` is unaffected (38 passed before, 39 after), since no existing test covered a text with a repeated word.
