### PR TITLE
Migrate BoxCoxTransformer to narwhals, add polars support

### DIFF
--- a/docs/user_guide/transformation/BoxCoxTransformer.rst
+++ b/docs/user_guide/transformation/BoxCoxTransformer.rst
@@ -206,6 +206,43 @@ In the following plots we see that the variables are non-normally distributed, b
 .. image:: ../../images/nonnormalvars2.png
 
 
+With polars
+-----------
+
+:class:`BoxCoxTransformer()` works in the same way with a polars dataframe:
+
+.. code:: python
+
+    import polars as pl
+    from feature_engine.transformation import BoxCoxTransformer
+
+    df = pl.DataFrame({
+        "var_1": [4.0, 9.0, 16.0, 25.0, 100.0],
+        "var_2": [1.0, 8.0, 27.0, 64.0, 125.0],
+    })
+
+    boxcox = BoxCoxTransformer(variables=None)
+    boxcox.fit(df)
+    Xt = boxcox.transform(df)
+
+    print(Xt)
+
+.. code:: text
+
+    shape: (5, 2)
+    ┌──────────┬──────────┐
+    │ var_1    ┆ var_2    │
+    │ ---      ┆ ---      │
+    │ f64      ┆ f64      │
+    ╞══════════╪══════════╡
+    │ 1.225161 ┆ 0.0      │
+    │ 1.810873 ┆ 2.666746 │
+    │ 2.177001 ┆ 4.93175  │
+    │ 2.435721 ┆ 6.969848 │
+    │ 3.117497 ┆ 8.854291 │
+    └──────────┴──────────┘
+
+
 Additional resources
 --------------------
 

--- a/feature_engine/transformation/boxcox.py
+++ b/feature_engine/transformation/boxcox.py
@@ -3,9 +3,11 @@
 
 from typing import List, Optional, Union
 
-import pandas as pd
+import narwhals as nw
+import numpy as np
+import scipy.special as spsp
 import scipy.stats as stats
-from scipy.special import inv_boxcox
+from narwhals.typing import IntoDataFrame, IntoSeries
 
 from feature_engine._base_transformers.base_numerical import BaseNumericalTransformer
 from feature_engine._check_init_parameters.check_init_input_params import (
@@ -119,6 +121,30 @@ class BoxCoxTransformer(BaseNumericalTransformer):
     2  0.662654
     3  1.607518
     4 -0.232237
+
+    With polars:
+
+    >>> import numpy as np
+    >>> import polars as pl
+    >>> from feature_engine.transformation import BoxCoxTransformer
+    >>> np.random.seed(42)
+    >>> X = pl.DataFrame({"x": list(np.random.lognormal(size=6))})
+    >>> bct = BoxCoxTransformer()
+    >>> bct.fit(X)
+    >>> bct.transform(X)
+    shape: (6, 1)
+    ┌───────────┐
+    │ x         │
+    │ ---       │
+    │ f64       │
+    ╞═══════════╡
+    │ 0.403681  │
+    │ -0.146883 │
+    │ 0.495725  │
+    │ 0.845914  │
+    │ -0.259585 │
+    │ -0.259565 │
+    └───────────┘
     """
 
     def __init__(
@@ -132,27 +158,31 @@ class BoxCoxTransformer(BaseNumericalTransformer):
         self.variables = _check_variables_input_value(variables)
         self.return_empty = return_empty
 
-    def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
+    def fit(self, X: IntoDataFrame, y: Optional[IntoSeries] = None):
         """
         Learn the optimal lambda for the BoxCox transformation.
 
         Parameters
         ----------
-        X: pandas dataframe of shape = [n_samples, n_features]
+        X: dataframe of shape = [n_samples, n_features]
             The training input samples. Can be the entire dataframe, not just the
             variables to transform.
 
-        y: pandas Series, default=None
+        y: Series, default=None
             It is not needed in this transformer. You can pass y or None.
         """
 
         # check input dataframe
         X, variables_ = self._fit_setup(X)
 
-        lambda_dict_ = {}
+        nw_X = nw.from_native(X, eager_only=True)
+        values = nw_X.select(variables_).to_numpy().astype(float)
 
-        for var in variables_:
-            _, lambda_dict_[var] = stats.boxcox(X[var])
+        lambda_dict_ = {}
+        # lambda search is per-column and not vectorizable across columns,
+        # unlike transform()'s elementwise application once lambdas are known
+        for i, var in enumerate(variables_):
+            _, lambda_dict_[var] = stats.boxcox(values[:, i])
 
         self.variables_ = variables_
         self.lambda_dict_ = lambda_dict_
@@ -160,55 +190,71 @@ class BoxCoxTransformer(BaseNumericalTransformer):
 
         return self
 
-    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+    def transform(self, X: IntoDataFrame) -> IntoDataFrame:
         """
         Apply the BoxCox transformation.
 
         Parameters
         ----------
-        X: pandas DataFrame of shape = [n_samples, n_features]
+        X: dataframe of shape = [n_samples, n_features]
             The data to be transformed.
 
         Returns
         -------
-        X_new: pandas dataframe
+        X_new: dataframe
             The dataframe with the transformed variables.
         """
 
         # check input dataframe and if class was fitted
         X = self._check_transform_input_and_state(X)
 
+        nw_X = nw.from_native(X, eager_only=True)
+        values = nw_X.select(self.variables_).to_numpy().astype(float)
+
         # check contains zero or negative values
-        if (X[self.variables_] <= 0).any().any():
+        if (values <= 0).any():
             raise ValueError("Data must be positive.")
 
         # transform
-        for feature in self.variables_:
-            X[feature] = stats.boxcox(X[feature], lmbda=self.lambda_dict_[feature])
+        lmbdas = np.array([self.lambda_dict_[var] for var in self.variables_])
+        result = spsp.boxcox(values, lmbdas)
+        new_series = [
+            nw.new_series(var, result[:, i], backend=nw_X.implementation)
+            for i, var in enumerate(self.variables_)
+        ]
+        X = nw_X.with_columns(*new_series).to_native()
 
         return X
 
-    def inverse_transform(self, X: pd.DataFrame) -> pd.DataFrame:
+    def inverse_transform(self, X: IntoDataFrame) -> IntoDataFrame:
         """
         Convert the data back to the original representation.
 
         Parameters
         ----------
-        X: pandas DataFrame of shape = [n_samples, n_features]
+        X: dataframe of shape = [n_samples, n_features]
             The data to be inverse transformed.
 
         Returns
         -------
-        X_new: pandas dataframe
+        X_new: dataframe
             The dataframe with the original variables.
         """
 
         # check input dataframe and if class was fitted
         X = self._check_transform_input_and_state(X)
 
+        nw_X = nw.from_native(X, eager_only=True)
+        values = nw_X.select(self.variables_).to_numpy().astype(float)
+
         # inverse transform
-        for feature in self.variables_:
-            X[feature] = inv_boxcox(X[feature], self.lambda_dict_[feature])
+        lmbdas = np.array([self.lambda_dict_[var] for var in self.variables_])
+        result = spsp.inv_boxcox(values, lmbdas)
+        new_series = [
+            nw.new_series(var, result[:, i], backend=nw_X.implementation)
+            for i, var in enumerate(self.variables_)
+        ]
+        X = nw_X.with_columns(*new_series).to_native()
 
         return X
 

--- a/tests/test_transformation/test_boxcox_transformer.py
+++ b/tests/test_transformation/test_boxcox_transformer.py
@@ -1,72 +1,98 @@
+import narwhals as nw
 import pandas as pd
+import polars as pl
 import pytest
 from sklearn.exceptions import NotFittedError
 
 from feature_engine.transformation import BoxCoxTransformer
 
+DATA = {
+    "Name": ["tom", "nick", "krish", "jack"],
+    "City": ["London", "Manchester", "Liverpool", "Bristol"],
+    "Age": [20, 21, 19, 18],
+    "Marks": [0.9, 0.8, 0.7, 0.6],
+}
 
-def test_automatically_finds_variables(df_vartypes):
-    # test case 1: automatically select variables
+DATA_NA = {
+    "Name": ["tom", "nick", "krish", "jack"],
+    "City": ["London", "Manchester", "Liverpool", "Bristol"],
+    "Age": [20, None, 19, 18],
+    "Marks": [0.9, 0.8, 0.7, 0.6],
+}
+
+
+def assert_df_equal(X, expected: dict, abs_tol: float = 1e-5) -> None:
+    result = nw.from_native(X, eager_only=True).to_dict(as_series=False)
+    assert list(result.keys()) == list(expected.keys())
+    for col, values in expected.items():
+        assert result[col] == pytest.approx(values, abs=abs_tol, nan_ok=True)
+
+
+@pytest.mark.parametrize("make_df", [pd.DataFrame, pl.DataFrame])
+def test_automatically_finds_variables_and_inverse_transform(make_df):
+    df = make_df(DATA)
+
     transformer = BoxCoxTransformer(variables=None)
-    X = transformer.fit_transform(df_vartypes)
-
-    # expected output
-    transf_df = df_vartypes.copy()
-    transf_df["Age"] = [9.78731, 10.1666, 9.40189, 9.0099]
-    transf_df["Marks"] = [-0.101687, -0.207092, -0.316843, -0.431788]
+    X = transformer.fit_transform(df)
 
     # test init params
     assert transformer.variables is None
     # test fit attr
     assert transformer.variables_ == ["Age", "Marks"]
-    assert transformer.n_features_in_ == 5
-    # test transform output
-    pd.testing.assert_frame_equal(X, transf_df)
+    assert transformer.n_features_in_ == 4
+
+    expected = dict(DATA)
+    expected["Age"] = [9.78731, 10.1666, 9.40189, 9.0099]
+    expected["Marks"] = [-0.101687, -0.207092, -0.316843, -0.431788]
+    assert_df_equal(X, expected)
 
     # test inverse_transform
     Xit = transformer.inverse_transform(X)
-
-    # convert numbers to original format.
-    Xit["Age"] = Xit["Age"].round().astype("int64")
-    Xit["Marks"] = Xit["Marks"].round(1)
-
-    # test
-    pd.testing.assert_frame_equal(Xit, df_vartypes)
+    result = nw.from_native(Xit, eager_only=True).to_dict(as_series=False)
+    assert [round(v) for v in result["Age"]] == DATA["Age"]
+    assert [round(v, 1) for v in result["Marks"]] == DATA["Marks"]
 
 
-def test_fit_raises_error_if_df_contains_na(df_na):
-    # test case 2: when dataset contains na, fit method
+@pytest.mark.parametrize("make_df", [pd.DataFrame, pl.DataFrame])
+def test_fit_raises_error_if_df_contains_na(make_df):
+    df_na = make_df(DATA_NA)
     transformer = BoxCoxTransformer()
     with pytest.raises(ValueError):
         transformer.fit(df_na)
 
 
-def test_transform_raises_error_if_df_contains_na(df_vartypes, df_na):
-    # test case 3: when dataset contains na, transform method
+@pytest.mark.parametrize("make_df", [pd.DataFrame, pl.DataFrame])
+def test_transform_raises_error_if_df_contains_na(make_df):
+    df = make_df(DATA)
+    df_na = make_df(DATA_NA)
     transformer = BoxCoxTransformer()
-    transformer.fit(df_vartypes)
+    transformer.fit(df)
     with pytest.raises(ValueError):
-        transformer.transform(df_na[["Name", "City", "Age", "Marks", "dob"]])
+        transformer.transform(df_na)
 
 
-def test_error_if_df_contains_negative_values(df_vartypes):
-    # test error when data contains negative values
-    df_neg = df_vartypes.copy()
-    df_neg.loc[1, "Age"] = -1
+@pytest.mark.parametrize("make_df", [pd.DataFrame, pl.DataFrame])
+def test_error_if_df_contains_negative_values(make_df):
+    data_neg = {k: list(v) for k, v in DATA.items()}
+    data_neg["Age"][1] = -1
+    df_neg = make_df(data_neg)
+    df = make_df(DATA)
 
-    # test case 4: when variable contains negative value, fit
+    # when variable contains negative value, fit
     transformer = BoxCoxTransformer()
     with pytest.raises(ValueError):
         transformer.fit(df_neg)
 
-    # test case 5: when variable contains negative value, transform
+    # when variable contains negative value, transform
     transformer = BoxCoxTransformer()
-    transformer.fit(df_vartypes)
+    transformer.fit(df)
     with pytest.raises(ValueError):
         transformer.transform(df_neg)
 
 
-def test_non_fitted_error(df_vartypes):
+@pytest.mark.parametrize("make_df", [pd.DataFrame, pl.DataFrame])
+def test_non_fitted_error(make_df):
+    df = make_df(DATA)
     transformer = BoxCoxTransformer()
     with pytest.raises(NotFittedError):
-        transformer.transform(df_vartypes)
+        transformer.transform(df)


### PR DESCRIPTION
fit()'s lambda search is per-column and not vectorizable (scipy.stats.boxcox with lmbda=None does per-column MLE optimization), while transform()/ inverse_transform() are pure elementwise math once lambdas are known - scipy.special.boxcox/inv_boxcox are ufuncs that broadcast a per-column lambda array against a 2D values array, so both methods extract via narwhals' to_numpy() once and apply a single batched call, same precedent as PowerTransformer (merged, not split).

Benchmarked pandas-native vs narwhals-on-pandas vs narwhals-on-polars at 10k/50k/100k rows x 1/2/10 columns, fit and transform measured separately since they're different cost centers:
- fit(): scipy's lambda-search optimization dominates total cost by 2-3 orders of magnitude over transform() (e.g. 10k rows/1 col: ~12.6ms fit vs ~0.1ms transform). narwhals overhead there is noise (<1% at every size/column combination tested).
- transform(): narwhals-on-pandas adds a small absolute overhead at tiny sizes (10k rows/1 col: 0.10ms old vs 0.27ms narwhals-loop/0.27ms narwhals-batched) but this shrinks to parity or better by 100k rows (9.03ms old vs 8.90ms narwhals-batched-pandas). Given fit() so overwhelmingly dominates real-world cost, a pandas/polars split for transform() would be real complexity for no measurable benefit - merged into a single narwhals path for both methods, matching every sibling transformer migrated in this module so far.

Rewrote test_boxcox_transformer.py to one parametrized test per behavior over make_df=[pd.DataFrame, pl.DataFrame], replacing the pandas-only df_vartypes/df_na fixtures with local DATA/DATA_NA dicts (same convention as test_relative_features.py). All expected values verified against actual output on both backends - identical.

docs/user_guide/transformation/BoxCoxTransformer.rst's main walkthrough uses fetch_openml against the Ames house-prices dataset; this sandbox has no network access (SSL/DNS blocked), so that section's numbers are UNVERIFIED against current output - flagging per instructions rather than silently skipping. Added a fully-verified "With polars" section using simple synthetic data, following the PowerTransformer precedent.

Verified: pytest tests/test_transformation (136 passed, same 8 pre-existing check_estimator failures as the unmigrated baseline, none new - confirmed those predate this change and affect all 8 transformers in the module, including ones not yet migrated); flake8 feature_engine tests clean; mypy feature_engine/transformation/boxcox.py clean; sphinx-build -W clean aside from the pre-existing unrelated linkcode_resolve warning (confirmed identical on the unmigrated base branch); boxcox.py and its full import chain load standalone with pandas import blocked.