### PR TITLE
Short-circuit _check_contains_na when variables list is empty

### DIFF
--- a/feature_engine/dataframe_checks.py
+++ b/feature_engine/dataframe_checks.py
@@ -227,6 +227,8 @@ def _check_contains_na(
         "remove those before using this transformer or set the parameter "
         "`missing_values='ignore'` when initialising this transformer."
     )
+    if len(variables) == 0:
+        return
     nw_X = nw.from_native(X, eager_only=True)
     if nwd.is_pandas_dataframe(X):
         numeric_vars = list(X[variables].select_dtypes(include="number").columns)

--- a/tests/test_dataframe_checks.py
+++ b/tests/test_dataframe_checks.py
@@ -423,6 +423,14 @@ def test_contains_na_raises_for_mix_of_null_and_nan_across_dtypes(make_df):
         _check_contains_na(df, ["Age", "City"])
 
 
+@pytest.mark.parametrize("make_df", [pd.DataFrame, pl.DataFrame])
+def test_contains_na_no_ops_when_variables_is_empty(make_df):
+    # on the narwhals/polars backend, nw.col([]) raises a TypeError, so an
+    # empty `variables` list must short-circuit before any column selection
+    df = make_df({"Name": ["tom", None], "City": ["London", "Manchester"]})
+    assert _check_contains_na(df, []) is None
+
+
 # --------------------------
 # test _check_contains_inf
 # --------------------------


### PR DESCRIPTION
## What

Add an early return to `_check_contains_na()` when `variables` is an empty list.

## Why

After the narwhals migration, `_check_contains_na` builds column selections with `nw.col(variables)` / `nw_X.select(variables)`. On the narwhals/polars backend, `nw.col([])` raises a `TypeError`, so an empty `variables` list must be handled before any column selection happens. The previous pandas-only implementation tolerated an empty list implicitly (`X[[]].select_dtypes(...)` is a no-op).

## Changes

- `feature_engine/dataframe_checks.py`: `return` early when `len(variables) == 0`.
- `tests/test_dataframe_checks.py`: add `test_contains_na_no_ops_when_variables_is_empty`, parametrized over pandas and polars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)