### PR TITLE
Wrap check_estimator inputs as dataframes in sklearn-compat tests

### DIFF
--- a/tests/estimator_checks/sklearn_check_wrapper.py
+++ b/tests/estimator_checks/sklearn_check_wrapper.py
@@ -50,10 +50,6 @@ class _SklearnCheckInputWrapper(TransformerMixin, BaseEstimator):
 
     def __init__(self, estimator=None, random_state=None):
         self.estimator = estimator
-        # Surfaced as a top-level param so sklearn's ``set_random_state`` (which
-        # only looks at shallow param names) can seed the wrapped estimator in
-        # the checks that require deterministic output, e.g.
-        # ``check_estimators_pickle`` / ``check_pipeline_consistency``.
         self.random_state = random_state
 
     @staticmethod

--- a/tests/estimator_checks/sklearn_check_wrapper.py
+++ b/tests/estimator_checks/sklearn_check_wrapper.py
@@ -1,0 +1,123 @@
+"""Adapter that lets sklearn's ``check_estimator`` run against Feature-engine
+transformers.
+
+``check_estimator`` feeds transformers numpy arrays. Feature-engine transformers
+only accept dataframes: ``feature_engine.dataframe_checks.check_X`` raises
+``TypeError`` on anything that is not a dataframe from a narwhals-supported
+library. Historically ``check_X`` itself converted numpy arrays into pandas
+dataframes (naming the columns ``x0``, ``x1``, ...) precisely so that these
+tests could run; that conversion is being removed as the checks migrate to
+narwhals.
+
+``wrap_for_check_estimator`` moves that adaptation into the test layer. It wraps
+a transformer in a thin meta-estimator that turns the numpy arrays coming from
+``check_estimator`` into pandas dataframes -- with the same ``x{i}`` column names
+``check_X`` used to assign -- before delegating to the wrapped transformer. Tags
+are delegated too, so ``check_estimator`` runs exactly the same set of checks it
+would run against the bare transformer, and the ``expected_failed_checks``
+dictionaries in the test files stay unchanged.
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, TransformerMixin, clone
+from sklearn.utils.validation import check_is_fitted
+
+
+def wrap_for_check_estimator(estimator):
+    """Wrap ``estimator`` so sklearn's ``check_estimator`` can feed it arrays.
+
+    Parameters
+    ----------
+    estimator : feature-engine transformer instance.
+
+    Returns
+    -------
+    _SklearnCheckInputWrapper
+        A meta-estimator delegating to ``estimator`` that converts numpy array
+        input into a pandas dataframe before every call.
+    """
+    return _SklearnCheckInputWrapper(estimator)
+
+
+class _SklearnCheckInputWrapper(TransformerMixin, BaseEstimator):
+    """Test-only shim: feeds the wrapped transformer a pandas dataframe when
+    sklearn's ``check_estimator`` passes numpy arrays.
+
+    Reproduces the numpy-array handling that
+    ``feature_engine.dataframe_checks.check_X`` used to provide.
+    """
+
+    def __init__(self, estimator=None, random_state=None):
+        self.estimator = estimator
+        # Surfaced as a top-level param so sklearn's ``set_random_state`` (which
+        # only looks at shallow param names) can seed the wrapped estimator in
+        # the checks that require deterministic output, e.g.
+        # ``check_estimators_pickle`` / ``check_pipeline_consistency``.
+        self.random_state = random_state
+
+    @staticmethod
+    def _to_df(X):
+        """Convert a numpy array into a dataframe, mirroring the old ``check_X``.
+
+        Dataframes are returned unchanged. Scalars, 1D arrays and complex data
+        raise the same errors ``check_X`` used to raise for them.
+        """
+        if hasattr(X, "iloc"):
+            return X
+
+        arr = np.asarray(X)
+        if arr.ndim == 0:
+            raise ValueError(
+                "Expected 2D array, got scalar array instead:\narray={}.\n"
+                "Reshape your data either using array.reshape(-1, 1) if your "
+                "data has a single feature or array.reshape(1, -1) if it "
+                "contains a single sample.".format(arr)
+            )
+        if arr.ndim == 1:
+            raise ValueError(
+                "Expected 2D array, got 1D array instead:\narray={}.\n"
+                "Reshape your data either using array.reshape(-1, 1) if your "
+                "data has a single feature or array.reshape(1, -1) if it "
+                "contains a single sample.".format(arr)
+            )
+        if np.iscomplexobj(arr):
+            raise TypeError("Complex data not supported by this transformer.")
+
+        return pd.DataFrame(arr, columns=[f"x{i}" for i in range(arr.shape[1])])
+
+    def fit(self, X, y=None):
+        self.estimator_ = clone(self.estimator)
+        if (
+            self.random_state is not None
+            and "random_state" in self.estimator_.get_params()
+        ):
+            self.estimator_.set_params(random_state=self.random_state)
+        if y is None:
+            self.estimator_.fit(self._to_df(X))
+        else:
+            self.estimator_.fit(self._to_df(X), y)
+
+        self.n_features_in_ = self.estimator_.n_features_in_
+        for attr in ("feature_names_in_", "classes_"):
+            if hasattr(self.estimator_, attr):
+                setattr(self, attr, getattr(self.estimator_, attr))
+        return self
+
+    def transform(self, X):
+        check_is_fitted(self)
+        return self.estimator_.transform(self._to_df(X))
+
+    def inverse_transform(self, X):
+        check_is_fitted(self)
+        return self.estimator_.inverse_transform(self._to_df(X))
+
+    def get_feature_names_out(self, input_features=None):
+        check_is_fitted(self)
+        return self.estimator_.get_feature_names_out(input_features)
+
+    def __sklearn_tags__(self):
+        return self.estimator.__sklearn_tags__()
+
+    def _more_tags(self):
+        return self.estimator._more_tags()

--- a/tests/test_creation/test_check_estimator_creation.py
+++ b/tests/test_creation/test_check_estimator_creation.py
@@ -16,6 +16,7 @@ from tests.estimator_checks.estimator_checks import check_feature_engine_estimat
 from tests.estimator_checks.non_fitted_error_checks import (
     check_raises_non_fitted_error_when_fit_fails,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -37,7 +38,7 @@ if sklearn_version > parse_version("1.6"):
     @pytest.mark.parametrize("estimator", _estimators)
     def test_check_estimator_from_sklearn(estimator):
         return check_estimator(
-            estimator=estimator,
+            estimator=wrap_for_check_estimator(estimator),
             expected_failed_checks=estimator._more_tags()["_xfail_checks"],
         )
 

--- a/tests/test_discretisation/test_check_estimator_discretisers.py
+++ b/tests/test_discretisation/test_check_estimator_discretisers.py
@@ -17,6 +17,7 @@ from tests.estimator_checks.estimator_checks import check_feature_engine_estimat
 from tests.estimator_checks.non_fitted_error_checks import (
     check_raises_non_fitted_error_when_fit_fails,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -40,7 +41,7 @@ else:
     @pytest.mark.parametrize("estimator", _estimators)
     def test_check_estimator_from_sklearn(estimator):
         return check_estimator(
-            estimator=estimator,
+            estimator=wrap_for_check_estimator(estimator),
             expected_failed_checks=estimator._more_tags()["_xfail_checks"],
         )
 

--- a/tests/test_encoding/test_check_estimator_encoders.py
+++ b/tests/test_encoding/test_check_estimator_encoders.py
@@ -24,6 +24,7 @@ from tests.estimator_checks.estimator_checks import (
     check_feature_engine_estimator,
     test_df,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -60,7 +61,8 @@ else:
     def test_check_estimator_from_sklearn(estimator):
         if estimator.__class__.__name__ != "WoEEncoder":
             return check_estimator(
-                estimator=estimator, expected_failed_checks=expected_fails
+                estimator=wrap_for_check_estimator(estimator),
+                expected_failed_checks=expected_fails,
             )
 
 

--- a/tests/test_imputation/test_check_estimator_imputers.py
+++ b/tests/test_imputation/test_check_estimator_imputers.py
@@ -18,6 +18,7 @@ from tests.estimator_checks.estimator_checks import check_feature_engine_estimat
 from tests.estimator_checks.non_fitted_error_checks import (
     check_raises_non_fitted_error_when_fit_fails,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 _estimators = [
     MeanImputer(),
@@ -42,7 +43,7 @@ else:
     @pytest.mark.parametrize("estimator", _estimators)
     def test_check_estimator_from_sklearn(estimator):
         return check_estimator(
-            estimator=estimator,
+            estimator=wrap_for_check_estimator(estimator),
             expected_failed_checks=estimator._more_tags()["_xfail_checks"],
         )
 

--- a/tests/test_outliers/test_check_estimator_outliers.py
+++ b/tests/test_outliers/test_check_estimator_outliers.py
@@ -8,6 +8,7 @@ from sklearn.utils.fixes import parse_version
 from feature_engine.outliers import ArbitraryOutlierCapper, OutlierTrimmer, Winsoriser
 from feature_engine.tags import _return_tags
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 _estimators = [
     ArbitraryOutlierCapper(max_capping_dict={"x0": 10}),
@@ -50,7 +51,10 @@ else:
         ],
     )
     def test_check_estimator_from_sklearn(estimator, failed_tests):
-        return check_estimator(estimator=estimator, expected_failed_checks=failed_tests)
+        return check_estimator(
+            estimator=wrap_for_check_estimator(estimator),
+            expected_failed_checks=failed_tests,
+        )
 
 
 @pytest.mark.parametrize("estimator", _estimators)

--- a/tests/test_preprocessing/test_check_estimator_preprocessing.py
+++ b/tests/test_preprocessing/test_check_estimator_preprocessing.py
@@ -14,6 +14,7 @@ from tests.estimator_checks.estimator_checks import (
     check_feature_engine_estimator,
     test_df,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -51,7 +52,10 @@ else:
         ],
     )
     def test_check_estimator_from_sklearn(estimator, failed_tests):
-        return check_estimator(estimator=estimator, expected_failed_checks=failed_tests)
+        return check_estimator(
+            estimator=wrap_for_check_estimator(estimator),
+            expected_failed_checks=failed_tests,
+        )
 
 
 @pytest.mark.parametrize("estimator", [MatchCategories(), MatchVariables()])

--- a/tests/test_selection/test_check_estimator_selectors.py
+++ b/tests/test_selection/test_check_estimator_selectors.py
@@ -28,6 +28,7 @@ from tests.estimator_checks.init_params_triggered_functionality_checks import (
     check_confirm_variables,
     check_raises_error_if_only_1_variable,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
@@ -103,7 +104,8 @@ else:
         ]:
             failed_tests = estimator._more_tags()["_xfail_checks"]
             return check_estimator(
-                estimator=estimator, expected_failed_checks=failed_tests
+                estimator=wrap_for_check_estimator(estimator),
+                expected_failed_checks=failed_tests,
             )
 
 

--- a/tests/test_time_series/test_forecasting/test_check_estimator_forecasting.py
+++ b/tests/test_time_series/test_forecasting/test_check_estimator_forecasting.py
@@ -13,6 +13,7 @@ from feature_engine.timeseries.forecasting import (
     WindowFeatures,
 )
 from tests.estimator_checks.estimator_checks import check_feature_engine_estimator
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 _estimators = [
     LagFeatures(missing_values="ignore"),
@@ -37,7 +38,7 @@ else:
             "or infinity."
         }
         return check_estimator(
-            estimator=estimator,
+            estimator=wrap_for_check_estimator(estimator),
             expected_failed_checks={
                 **extra_failing_checks,
                 **estimator._more_tags()["_xfail_checks"],

--- a/tests/test_transformation/test_check_estimator_transformers.py
+++ b/tests/test_transformation/test_check_estimator_transformers.py
@@ -19,6 +19,7 @@ from tests.estimator_checks.estimator_checks import check_feature_engine_estimat
 from tests.estimator_checks.non_fitted_error_checks import (
     check_raises_non_fitted_error_when_fit_fails,
 )
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 
 _estimators = [
     BoxCoxTransformer(),
@@ -75,7 +76,7 @@ else:
             extra_failing_checks.get(estimator.__class__.__name__, {})
         )
         return check_estimator(
-            estimator=estimator,
+            estimator=wrap_for_check_estimator(estimator),
             expected_failed_checks=expected_failed_checks,
         )
 

--- a/tests/test_wrappers/test_check_estimator_wrappers.py
+++ b/tests/test_wrappers/test_check_estimator_wrappers.py
@@ -12,6 +12,7 @@ from tests.estimator_checks.estimator_checks import (
 )
 from tests.estimator_checks.fit_functionality_checks import check_feature_names_in
 from tests.estimator_checks.non_fitted_error_checks import check_raises_non_fitted_error
+from tests.estimator_checks.sklearn_check_wrapper import wrap_for_check_estimator
 from tests.estimator_checks.variable_selection_checks import (
     check_all_types_variables_assignment,
     check_numerical_variables_assignment,
@@ -28,7 +29,9 @@ else:
 
     def test_sklearn_transformer_wrapper():
         check_estimator(
-            estimator=SklearnWrapper(transformer=SimpleImputer()),
+            estimator=wrap_for_check_estimator(
+                SklearnWrapper(transformer=SimpleImputer())
+            ),
             expected_failed_checks=SklearnWrapper(
                 transformer=SimpleImputer()
             )._more_tags()["_xfail_checks"],


### PR DESCRIPTION
## What

sklearn's `check_estimator` feeds transformers **numpy arrays**. The
`test_check_estimator_from_sklearn` tests only pass today because
`feature_engine.dataframe_checks.check_X` silently converts a numpy array into a
pandas dataframe (columns `x0`, `x1`, …). That conversion is being removed as
`check_X` migrates to narwhals, which breaks these tests on every `narwhals-*`
branch.

This PR moves the array→dataframe adaptation out of `check_X` and into the test
layer, so the sklearn-compat tests no longer depend on `check_X` accepting
arrays. **Test-only, no behaviour change** on `main`.

## How

New helper `tests/estimator_checks/sklearn_check_wrapper.py` exposes
`wrap_for_check_estimator(estimator)`: a thin meta-estimator that

- converts the numpy arrays coming from `check_estimator` into dataframes, using
  the same `x{i}` column names `check_X` used to assign, before delegating to the
  wrapped transformer;
- delegates `__sklearn_tags__` / `_more_tags`, so `check_estimator` runs exactly
  the same set of checks it runs against the bare transformer and the
  `expected_failed_checks` dictionaries are unchanged;
- exposes a top-level `random_state` so sklearn's `set_random_state` (which only
  inspects shallow param names) can still seed the wrapped estimator for the
  checks that require deterministic output (`check_estimators_pickle`,
  `check_pipeline_consistency`).

Every `test_check_estimator_from_sklearn` (10 modules: transformation, creation,
outliers, discretisation, preprocessing, selection, encoding, imputation,
timeseries/forecasting, wrappers) now wraps the `estimator=` argument.
`expected_failed_checks` is still computed from the bare estimator.

## Verification

- `pytest tests -k "check_estimator"` — 302 passed, identical to `main`.
- Merged into `narwhals-migration` locally (where `check_X` rejects arrays):
  `test_check_estimator_from_sklearn` goes from 4 passed / 51 failed to
  20 passed / 35 failed — every transformer already migrated to narwhals now
  passes its sklearn check; the rest fail only because those transformers
  themselves aren't migrated yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)