### PR TITLE
Pass min_periods to rolling() in WindowFeatures

### DIFF
--- a/feature_engine/timeseries/forecasting/window_features.py
+++ b/feature_engine/timeseries/forecasting/window_features.py
@@ -221,7 +221,7 @@ class WindowFeatures(BaseForecastTransformer):
             for win in self.window:
                 tmp = (
                     X[self.variables_]
-                    .rolling(window=win)
+                    .rolling(window=win, min_periods=self.min_periods)
                     .agg(self.functions)
                     .shift(periods=self.periods, freq=self.freq)
                 )
@@ -231,7 +231,7 @@ class WindowFeatures(BaseForecastTransformer):
         else:
             tmp = (
                 X[self.variables_]
-                .rolling(window=self.window)
+                .rolling(window=self.window, min_periods=self.min_periods)
                 .agg(self.functions)
                 .shift(periods=self.periods, freq=self.freq)
             )

--- a/tests/test_time_series/test_forecasting/test_window_features.py
+++ b/tests/test_time_series/test_forecasting/test_window_features.py
@@ -452,6 +452,43 @@ def test_multiple_windows(df_time):
     assert df_time_tr.equals(X_tr)
 
 
+def test_min_periods_is_used(df_time):
+    # min_periods was accepted and documented but never reached pandas
+    # rolling(), so the leading rows stayed NaN whatever the user asked for.
+    variables = ["ambient_temp", "module_temp", "irradiation"]
+
+    transformer = WindowFeatures(window=3, min_periods=1)
+    df_tr = transformer.fit_transform(df_time)
+
+    expected = (
+        df_time[variables].rolling(window=3, min_periods=1).agg("mean").shift(periods=1)
+    )
+    expected.columns = [f"{var}_window_3_mean" for var in variables]
+
+    assert_frame_equal(df_tr[expected.columns], expected)
+
+    # with min_periods=1 only the very first row (shifted out) remains NaN
+    assert df_tr["ambient_temp_window_3_mean"].isna().sum() == 1
+
+    # the default is unchanged: pandas requires a full window
+    df_default = WindowFeatures(window=3).fit_transform(df_time)
+    assert df_default["ambient_temp_window_3_mean"].isna().sum() == 3
+
+
+def test_min_periods_is_used_with_multiple_windows(df_time):
+    transformer = WindowFeatures(window=[2, 3], min_periods=1)
+    df_tr = transformer.fit_transform(df_time)
+
+    for win in (2, 3):
+        expected = (
+            df_time["ambient_temp"].rolling(window=win, min_periods=1).mean().shift(1)
+        )
+        assert_frame_equal(
+            df_tr[[f"ambient_temp_window_{win}_mean"]],
+            expected.to_frame(f"ambient_temp_window_{win}_mean"),
+        )
+
+
 def test_sort_index(df_time):
     # Shuffle dataframe
     Xs = df_time.copy()


### PR DESCRIPTION
### What this fixes

`WindowFeatures` documents `min_periods` as a pandas passthrough:

> `min_periods: int, default None.` Minimum number of observations in the window required to have a value; otherwise, the result is np.nan. See parameter `min_periods` in pandas `rolling()` documentation for more details.

It is accepted and stored as `self.min_periods`, but `transform()` never reads it. Both branches build the window without it:

```python
X[self.variables_].rolling(window=win)          # list-of-windows branch
X[self.variables_].rolling(window=self.window)  # single-window branch
```

So `rolling()` keeps its default — a full window is required — and the leading rows stay `NaN` no matter what the user passes.

`ExpandingWindowFeatures` already does forward it (`.expanding(min_periods=self.min_periods)`), so the two transformers disagreed on a parameter they document in the same words.

### Evidence

A 6-row frame, `window=3`, default `functions="mean"`, `periods=1`:

| | result |
|---|---|
| `min_periods=None` | `[nan, nan, nan, 2.0, 3.0, 4.0]` |
| `min_periods=1` (before) | `[nan, nan, nan, 2.0, 3.0, 4.0]` — identical, flag inert |
| `min_periods=1` (after) | `[nan, 1.0, 1.5, 2.0, 3.0, 4.0]` |
| `X["x"].rolling(3, min_periods=1).mean().shift(1)` | `[nan, 1.0, 1.5, 2.0, 3.0, 4.0]` |

After the change the output matches pandas exactly, for a single window and for a list of windows.

### Compatibility

The default is unchanged. `min_periods=None` is precisely what `rolling()` was already assuming, so anyone who never set the parameter sees identical output. Only users who explicitly passed it see a change — and it is the documented behaviour they asked for.

### Testing

Added `test_min_periods_is_used` and `test_min_periods_is_used_with_multiple_windows`, comparing against pandas `rolling(...)` directly and asserting the default still requires a full window.

- without the fix: both fail
- with the fix: both pass
- `tests/test_time_series`: 121 passed
- flake8 and black clean on both files
